### PR TITLE
Removed Custom Monitor

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,9 +5,7 @@ import {
   SectionTimeline,
 } from "./components/Sections";
 
-export const dynamic = "force-dynamic";
-
-export default async function Home() {
+export default function Home() {
   return (
     <>
       <SectionIntro />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,22 +4,10 @@ import {
   SectionMySelf,
   SectionTimeline,
 } from "./components/Sections";
-import statisticsService from "@/services/statistics.service";
 
 export const dynamic = "force-dynamic";
 
-const increaseViewCount = async () => {
-  try {
-    await statisticsService.addView();
-  } catch (err) {
-    console.error("Error adding a view statistic:");
-    console.error(err);
-  }
-};
-
 export default async function Home() {
-  await increaseViewCount();
-
   return (
     <>
       <SectionIntro />


### PR DESCRIPTION
Removed the custom website usage monitor. Vercel Analystics are used now. This custom feature makes it difficult to migrate NextJS. Prisma is still there but not used in any pages. Prisma will be used in the future.