### PR TITLE
Build secure money workspace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,3 @@ SITE_URL="https://your-domain.example"
 
 # Keep this stable and secret. Use at least 32 random characters.
 AUTH_SECRET="replace-with-a-long-random-secret"
-
-# Used only to create the first database-backed admin account.
-# Remove both variables from the deployment after the first successful login.
-ADMIN_BOOTSTRAP_USERNAME="admin"
-ADMIN_BOOTSTRAP_PASSWORD="replace-with-a-strong-temporary-password"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+DATABASE_URL="mongodb+srv://USER:PASSWORD@HOST/portfolio"
+SITE_URL="https://your-domain.example"
+
+# Keep this stable and secret. Use at least 32 random characters.
+AUTH_SECRET="replace-with-a-long-random-secret"
+
+# Used only to create the first database-backed admin account.
+# Remove both variables from the deployment after the first successful login.
+ADMIN_BOOTSTRAP_USERNAME="admin"
+ADMIN_BOOTSTRAP_PASSWORD="replace-with-a-strong-temporary-password"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,35 @@
 
 My awesome portfolio with hidden tools 😂😂
 
-## Plan
+## Money workspace
+
+The private `/admin` area now includes a maintainable SGD ledger with:
+
+- database-backed admin credentials and bcrypt password hashing;
+- signed, expiring, HTTP-only sessions verified by the edge proxy;
+- profile and password management with session invalidation;
+- exact integer-cent money calculations, opening balance, and IN/OUT entries;
+- top-level categories, one level of subcategories, and a protected Unclassified category;
+- category suggestions and automatic creation while entering a transaction;
+- filtered statistics, cash-flow and spending charts, and paginated transactions;
+- a compact oldest-first mobile ledger and an adaptive desktop dashboard.
+
+### First deployment
+
+1. Copy the variables from `.env.example` into the local/deployment environment. Keep `AUTH_SECRET` stable and private.
+2. Run `pnpm prisma db push` against the intended MongoDB database, then deploy.
+3. Sign in once with `ADMIN_BOOTSTRAP_USERNAME` and `ADMIN_BOOTSTRAP_PASSWORD`. This creates the first `AdminUser` with a bcrypt hash.
+4. Remove the two `ADMIN_BOOTSTRAP_*` variables and manage credentials from `/admin/profile` thereafter.
+
+Older transaction documents are upgraded when first read: their original `amount` is converted to cents, their direction defaults to money out, and missing categories become Unclassified. Review any old income entries after deployment because the previous model did not record a direction.
+
+### Security notes
+
+- Every admin route is protected by `proxy.ts`; every mutating server action also performs its own authentication check.
+- Admin responses are private and non-cacheable. Baseline framing, MIME-sniffing, referrer, and permissions headers are configured in `next.config.ts`.
+- For internet exposure, enable rate limiting for `/admin/login` at the hosting/WAF layer. In-memory counters are not reliable in a serverless deployment.
+
+## Original plan
 
 - Improve proxy.ts
   - check if there any anti-patterns in it and fix them.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The private `/admin` area now includes a maintainable SGD ledger with:
 3. Sign in once with `ADMIN_BOOTSTRAP_USERNAME` and `ADMIN_BOOTSTRAP_PASSWORD`. This creates the first `AdminUser` with a bcrypt hash.
 4. Remove the two `ADMIN_BOOTSTRAP_*` variables and manage credentials from `/admin/profile` thereafter.
 
-Older transaction documents are upgraded when first read: their original `amount` is converted to cents, their direction defaults to money out, and missing categories become Unclassified. Review any old income entries after deployment because the previous model did not record a direction.
+The money schema intentionally starts fresh: transaction amounts, directions, and categories are required, and amounts are stored as integer cents.
 
 ### Security notes
 
@@ -43,7 +43,7 @@ Older transaction documents are upgraded when first read: their original `amount
   - check if auth-service.ts is used in a secured way in the proxy.ts, pages and actions. If there are security issues, fix them.
   - All pages afer 'admin' and including 'admin' can be accessed only by authenticated users.
 - Improve UI/UX of navigation bar
-- Improve "money" feature. This feature includes storing transactions. All transactions are in SGD. There are categories of transactions. A transaction can belong to only one category. Transactions that do not have a category fall into a category named "unclassified". unclassified category does not have sub categories. This feature start from path 'src\app\admin\money'.
+- Improve "money" feature. This feature includes storing transactions. All transactions are in SGD. There are categories of transactions. A transaction can belong to only one category. Transactions that do not have a category fall into a category named "unclassified". unclassified category does not have sub categories. This feature start from path 'src\\app\\admin\\money'.
   - User should be able add, edit, view and delete categories.
   - Categories should be able to have any number of sub categories except for unlcassified category. A subcategory does not have subcategories.
   - When adding a transaction, use can mention the category. If the mentioned category does not exist, it should be created when adding the transaction. When use types a category, a suggestion list should be displayed. If the typed category does not exist, a text should be displayed saying that a category will be created.

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,30 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   typedRoutes: true,
   reactCompiler: true,
+  poweredByHeader: false,
+  async headers() {
+    const securityHeaders = [
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "X-Frame-Options", value: "DENY" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=()",
+      },
+      {
+        key: "Content-Security-Policy",
+        value: "frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+      },
+    ];
+
+    return [
+      { source: "/(.*)", headers: securityHeaders },
+      {
+        source: "/admin/:path*",
+        headers: [{ key: "Cache-Control", value: "private, no-store" }],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vercel/analytics": "^2.0.1",
     "bcryptjs": "3.0.2",
     "cheerio": "^1.2.0",
+    "classnames": "^2.5.1",
     "dotenv": "^17.4.2",
     "jose": "6.1.3",
     "next": "16.3.0",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,15 @@
   "dependencies": {
     "@prisma/client": "^6.19.3",
     "@vercel/analytics": "^2.0.1",
+    "bcryptjs": "3.0.2",
     "cheerio": "^1.2.0",
     "dotenv": "^17.4.2",
+    "jose": "6.1.3",
     "next": "16.3.0",
     "next-mdx-remote": "^6.0.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
+    "recharts": "3.2.1",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
+      classnames:
+        specifier: ^2.5.1
+        version: 2.5.1
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -1160,6 +1163,9 @@ packages:
 
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -3925,6 +3931,8 @@ snapshots:
       consola: 3.4.2
 
   citty@0.2.2: {}
+
+  classnames@2.5.1: {}
 
   client-only@0.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.3.0(@babel/core@7.29.7)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0))(react@19.2.8)
+      bcryptjs:
+        specifier: 3.0.2
+        version: 3.0.2
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      jose:
+        specifier: 6.1.3
+        version: 6.1.3
       next:
         specifier: 16.3.0
         version: 16.3.0(@babel/core@7.29.7)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0)
@@ -32,6 +38,9 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
+      recharts:
+        specifier: 3.2.1
+        version: 3.2.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@16.13.1)(react@19.2.8)(redux@5.0.1)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -576,11 +585,25 @@ packages:
   '@prisma/get-platform@6.19.3':
     resolution: {integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==}
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -676,6 +699,33 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -719,6 +769,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.66.0':
     resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
@@ -1018,6 +1071,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bcryptjs@3.0.2:
+    resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
+    hasBin: true
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1107,6 +1164,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -1147,6 +1208,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1178,6 +1283,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1310,6 +1418,9 @@ packages:
   es-to-primitive@1.3.4:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -1465,6 +1576,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   exsolve@1.1.1:
     resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
@@ -1645,6 +1759,12 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.16:
+    resolution: {integrity: sha512-Xs7H9rBc+kti1J6RueUvbEBkmOz7jqj11XYgf+YMXAYzu8EeE7hwZ9poLXdVfVnGmJu7QAf41T7H2KuF6QoK6Q==}
+
   immutable@5.1.9:
     resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
@@ -1662,6 +1782,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -1799,6 +1923,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2291,6 +2418,18 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -2302,6 +2441,14 @@ packages:
   readdirp@5.1.1:
     resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
     engines: {node: '>= 20.19.0'}
+
+  recharts@3.2.1:
+    resolution: {integrity: sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -2316,6 +2463,14 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2336,6 +2491,9 @@ packages:
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2522,6 +2680,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -2631,6 +2792,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vfile-matter@5.0.1:
     resolution: {integrity: sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==}
 
@@ -2639,6 +2805,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -3198,9 +3367,23 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.19.3
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.16
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.8
+      react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3280,6 +3463,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -3321,6 +3528,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -3604,6 +3813,8 @@ snapshots:
 
   baseline-browser-mapping@2.11.12: {}
 
+  bcryptjs@3.0.2: {}
+
   boolbase@1.0.0: {}
 
   brace-expansion@1.1.18:
@@ -3717,6 +3928,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clsx@2.1.1: {}
+
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -3753,6 +3966,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -3780,6 +4031,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -3982,6 +4235,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.50.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -4239,6 +4494,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   exsolve@1.1.1: {}
 
   extend@3.0.2: {}
@@ -4459,6 +4716,10 @@ snapshots:
 
   ignore@7.0.6: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.16: {}
+
   immutable@5.1.9: {}
 
   import-fresh@3.3.1:
@@ -4475,6 +4736,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  internmap@2.0.3: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -4619,6 +4882,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.7.0: {}
+
+  jose@6.1.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -5298,11 +5563,40 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      redux: 5.0.1
+
   react@19.2.8: {}
 
   readdirp@4.1.2: {}
 
   readdirp@5.1.1: {}
+
+  recharts@3.2.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@16.13.1)(react@19.2.8)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.50.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 16.13.1
+      react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.8)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -5332,6 +5626,12 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5384,6 +5684,8 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -5629,6 +5931,8 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
@@ -5798,6 +6102,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
   vfile-matter@5.0.1:
     dependencies:
       vfile: 6.0.3
@@ -5812,6 +6120,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   whatwg-encoding@3.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,12 @@
 packages:
   - .
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver
+
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@prisma/client'
+  - '@prisma/engines'
+  - prisma

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,20 +38,52 @@ model RentingRoom {
 }
 
 model Category {
-  id           String        @id @default(auto()) @map("_id") @db.ObjectId
-  name         String
-  parentId     String?       @db.ObjectId
-  parent       Category?     @relation("CategoryHierarchy", fields: [parentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  categories   Category[]    @relation("CategoryHierarchy")
-  transactions Transaction[]
+  id             String        @id @default(auto()) @map("_id") @db.ObjectId
+  name           String
+  normalizedName String?
+  isSystem       Boolean       @default(false)
+  parentId       String?       @db.ObjectId
+  parent         Category?     @relation("CategoryHierarchy", fields: [parentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  children       Category[]    @relation("CategoryHierarchy")
+  transactions   Transaction[]
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 }
 
 model Transaction {
-  id         String    @id @default(auto()) @map("_id") @db.ObjectId
-  amount     Float
-  title      String
-  time       DateTime  @default(now())
-  comments   String?
-  category   Category? @relation(fields: [categoryId], references: [id])
-  categoryId String?   @db.ObjectId
+  id          String                @id @default(auto()) @map("_id") @db.ObjectId
+  amount      Float?
+  amountCents Int?
+  direction   TransactionDirection?
+  title       String
+  time        DateTime              @default(now())
+  comments    String?
+  category    Category?             @relation(fields: [categoryId], references: [id])
+  categoryId  String?               @db.ObjectId
+  createdAt   DateTime              @default(now())
+  updatedAt   DateTime              @updatedAt
+
+  @@index([time])
+  @@index([categoryId])
+}
+
+enum TransactionDirection {
+  IN
+  OUT
+}
+
+model MoneyAccount {
+  id                  String   @id @default("primary") @map("_id")
+  openingBalanceCents Int      @default(0)
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+}
+
+model AdminUser {
+  id             String   @id @default(auto()) @map("_id") @db.ObjectId
+  username       String   @unique
+  passwordHash   String
+  sessionVersion Int      @default(1)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,7 +40,7 @@ model RentingRoom {
 model Category {
   id             String        @id @default(auto()) @map("_id") @db.ObjectId
   name           String
-  normalizedName String?
+  normalizedName String        @unique
   isSystem       Boolean       @default(false)
   parentId       String?       @db.ObjectId
   parent         Category?     @relation("CategoryHierarchy", fields: [parentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
@@ -51,17 +51,16 @@ model Category {
 }
 
 model Transaction {
-  id          String                @id @default(auto()) @map("_id") @db.ObjectId
-  amount      Float?
-  amountCents Int?
-  direction   TransactionDirection?
+  id          String               @id @default(auto()) @map("_id") @db.ObjectId
+  amountCents Int
+  direction   TransactionDirection
   title       String
-  time        DateTime              @default(now())
+  time        DateTime             @default(now())
   comments    String?
-  category    Category?             @relation(fields: [categoryId], references: [id])
-  categoryId  String?               @db.ObjectId
-  createdAt   DateTime              @default(now())
-  updatedAt   DateTime              @updatedAt
+  category    Category             @relation(fields: [categoryId], references: [id])
+  categoryId  String               @db.ObjectId
+  createdAt   DateTime             @default(now())
+  updatedAt   DateTime             @updatedAt
 
   @@index([time])
   @@index([categoryId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,7 +57,7 @@ model Transaction {
   title       String
   time        DateTime             @default(now())
   comments    String?
-  category    Category             @relation(fields: [categoryId], references: [id])
+  category    Category             @relation(fields: [categoryId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   categoryId  String               @db.ObjectId
   createdAt   DateTime             @default(now())
   updatedAt   DateTime             @updatedAt

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import authService from "@/services/auth-service";
+import { redirect } from "next/navigation";
+
+export const logoutAction = async () => {
+  await authService.logout();
+  redirect("/admin/login");
+};

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic";
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/admin/login/actions.ts
+++ b/src/app/admin/login/actions.ts
@@ -20,16 +20,15 @@ export const loginAction = async (
   const parsed = loginSchema.safeParse(Object.fromEntries(data));
   if (!parsed.success) return { error: "Enter your username and password." };
 
-  if (await authService.login(parsed.data.username, parsed.data.password)) {
-    const c = await cookies();
-    const requestedPath = c.get(COOKIE_NAME_REDIRECTED_FROM)?.value;
-    c.delete(COOKIE_NAME_REDIRECTED_FROM);
-    const redirectedFrom =
-      requestedPath?.startsWith("/admin") && !requestedPath.startsWith("//")
-        ? (requestedPath as Route)
-        : "/admin";
-    redirect(redirectedFrom);
-  }
+  if (!(await authService.login(parsed.data.username, parsed.data.password)))
+    return { error: "Invalid username or password." };
 
-  return { error: "Invalid username or password." };
+  const c = await cookies();
+  const requestedPath = c.get(COOKIE_NAME_REDIRECTED_FROM)?.value;
+  c.delete(COOKIE_NAME_REDIRECTED_FROM);
+  const redirectedFrom =
+    requestedPath?.startsWith("/admin") && !requestedPath.startsWith("//")
+      ? (requestedPath as Route)
+      : "/admin";
+  redirect(redirectedFrom);
 };

--- a/src/app/admin/login/actions.ts
+++ b/src/app/admin/login/actions.ts
@@ -4,21 +4,32 @@ import authService from "@/services/auth-service";
 import { Route } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { z } from "zod";
 
-export const loginAction = async (data: FormData) => {
-  const username = data.get("username");
-  const password = data.get("password");
+export type LoginState = { error?: string };
 
-  if (
-    typeof username === "string" &&
-    typeof password === "string" &&
-    (await authService.login(username, password))
-  ) {
+const loginSchema = z.object({
+  username: z.string().trim().min(1).max(80),
+  password: z.string().min(1).max(200),
+});
+
+export const loginAction = async (
+  _previousState: LoginState,
+  data: FormData,
+): Promise<LoginState> => {
+  const parsed = loginSchema.safeParse(Object.fromEntries(data));
+  if (!parsed.success) return { error: "Enter your username and password." };
+
+  if (await authService.login(parsed.data.username, parsed.data.password)) {
     const c = await cookies();
-    const redirectedFrom = c.get(COOKIE_NAME_REDIRECTED_FROM)?.value as
-      | Route
-      | undefined;
+    const requestedPath = c.get(COOKIE_NAME_REDIRECTED_FROM)?.value;
     c.delete(COOKIE_NAME_REDIRECTED_FROM);
-    redirect(redirectedFrom || "/admin");
+    const redirectedFrom =
+      requestedPath?.startsWith("/admin") && !requestedPath.startsWith("//")
+        ? (requestedPath as Route)
+        : "/admin";
+    redirect(redirectedFrom);
   }
+
+  return { error: "Invalid username or password." };
 };

--- a/src/app/admin/login/components/LoginButton.tsx
+++ b/src/app/admin/login/components/LoginButton.tsx
@@ -10,7 +10,7 @@ export default function LoginButton() {
       className="bg-blue-500 text-white p-2 rounded enabled:cursor-pointer disabled:opacity-50"
       disabled={pending}
     >
-      Login
+      {pending ? "Signing in…" : "Sign in"}
     </button>
   );
 }

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,36 +1,56 @@
+"use client";
+
 import PageContainer from "@/components/PageContainer";
-import Header1 from "@/components/Header1";
+import { useActionState } from "react";
 import { loginAction } from "./actions";
 import LoginButton from "./components/LoginButton";
 
-export default async function LoginPage() {
-  return (
-    <PageContainer className="grid grid-rows-[auto_1fr] items-center h-screen">
-      <Header1>Access Admin Part</Header1>
+export default function LoginPage() {
+  const [state, action] = useActionState(loginAction, {});
 
-      <form
-        className="flex flex-col gap-4 max-w-sm mx-auto w-full"
-        action={loginAction}
-      >
-        <p className="text-gray-600 text-center">
-          This is a protected admin page. Only authorized users can access this
-          section.
+  return (
+    <main className="admin-shell min-h-screen grid place-items-center px-5 py-10">
+      <PageContainer className="admin-panel w-full max-w-md rounded-3xl p-7 sm:p-10">
+        <p className="admin-eyebrow">Private workspace</p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+          Welcome back
+        </h1>
+        <p className="mt-3 text-sm text-slate-400">
+          Sign in to access your financial dashboard and admin tools.
         </p>
 
-        <input
-          type="text"
-          name="username"
-          required
-          className="p-2 border border-gray-300 rounded"
-        />
-        <input
-          type="password"
-          name="password"
-          required
-          className="p-2 border border-gray-300 rounded"
-        />
-        <LoginButton />
-      </form>
-    </PageContainer>
+        <form className="mt-8 grid gap-5" action={action}>
+          <label className="grid gap-2 text-sm font-medium">
+            Username
+            <input
+              type="text"
+              name="username"
+              autoComplete="username"
+              required
+              maxLength={80}
+              className="admin-input"
+            />
+          </label>
+          <label className="grid gap-2 text-sm font-medium">
+            Password
+            <input
+              type="password"
+              name="password"
+              autoComplete="current-password"
+              required
+              maxLength={200}
+              className="admin-input"
+            />
+          </label>
+
+          {state.error && (
+            <p role="alert" className="text-sm text-rose-300">
+              {state.error}
+            </p>
+          )}
+          <LoginButton />
+        </form>
+      </PageContainer>
+    </main>
   );
 }

--- a/src/app/admin/money/categories/[id]/actions.ts
+++ b/src/app/admin/money/categories/[id]/actions.ts
@@ -1,40 +1,35 @@
 "use server";
-import { revalidatePath } from "next/cache";
+
+import authService from "@/services/auth-service";
 import categoriesService, {
   CreateCategoryDto,
   UpdateCategoryDto,
 } from "@/services/categories.service";
-import ValidationException from "@/exceptions/validation.exception";
+import { revalidatePath } from "next/cache";
 
 export const deleteAction = async (id: string) => {
+  await authService.requireAuthenticatedUser();
   await categoriesService.deleteCategory(id);
-  revalidatePath(`/admin/money/categories/${id}`);
   revalidatePath("/admin/money/categories");
+  revalidatePath("/admin/money/transactions");
 };
 
 export const createAction = async (params: CreateCategoryDto) => {
-  if (await categoriesService.nameExists(params.name))
-    throw new ValidationException("A category with that name already exists.");
-
+  await authService.requireAuthenticatedUser();
+  if (await categoriesService.nameExists(params.name)) {
+    throw new Error("A category with that name already exists.");
+  }
   const created = await categoriesService.createCategory(params);
-  revalidatePath(`/admin/money/categories/${created.id}`);
   revalidatePath("/admin/money/categories");
   return created.id;
 };
 
 export const updateAction = async (id: string, params: UpdateCategoryDto) => {
-  if (params.name && (await categoriesService.nameExists(params.name)))
-    throw new ValidationException("A category with that name already exists.");
-
+  await authService.requireAuthenticatedUser();
+  if (params.name && (await categoriesService.nameExists(params.name, id))) {
+    throw new Error("A category with that name already exists.");
+  }
   await categoriesService.updateCategory(id, params);
-  revalidatePath(`/admin/money/categories/${id}`);
   revalidatePath("/admin/money/categories");
-};
-
-export const getCategoriesForDropdown = async (currentCatId: string) => {
-  const categories =
-    await categoriesService.getNonChildCategories(currentCatId);
-  return categories
-    .filter((cat) => cat.id !== currentCatId)
-    .map((cat) => ({ id: cat.id, name: cat.name }));
+  revalidatePath("/admin/money/transactions");
 };

--- a/src/app/admin/money/categories/[id]/components/ClientForm.tsx
+++ b/src/app/admin/money/categories/[id]/components/ClientForm.tsx
@@ -9,18 +9,22 @@ import {
   SelectOption,
 } from "@/components/FormFields";
 import Form from "@/components/Form";
-import { Category } from "@/generated/prisma/browser";
 import {
   createAction,
-  getCategoriesForDropdown,
   updateAction,
   deleteAction,
 } from "../actions";
 
+type Category = {
+  id: string;
+  name: string;
+  parentId: string | null;
+  isSystem: boolean;
+};
+
 type ClientFormProps = {
   isNew: boolean;
   category?: Category | null;
-  hasChildCategories?: boolean;
   categories: Pick<Category, "id" | "name">[];
 };
 
@@ -44,7 +48,6 @@ export default function ClientForm(props: Readonly<ClientFormProps>) {
   const router = useRouter();
   const form = useRef<HTMLFormElement>(null);
   const [parentId, setParentId] = useState(props.category?.parentId ?? "");
-  const [categories, setCategories] = useState(props.categories);
   const [pending, setPending] = useState(false);
 
   const onSaveClick = useCallback(async () => {
@@ -53,10 +56,7 @@ export default function ClientForm(props: Readonly<ClientFormProps>) {
       const newId = await _onSaveClick(form.current!, props.category?.id);
       if (props.isNew) {
         router.push(`/admin/money/categories/${newId}`);
-      } else {
-        const cats = await getCategoriesForDropdown(newId);
-        setCategories(cats);
-      }
+      } else router.refresh();
     } catch (error) {
       console.error(error);
       if (error instanceof Error) alert(error.message);
@@ -80,13 +80,15 @@ export default function ClientForm(props: Readonly<ClientFormProps>) {
   }, [props.category, router]);
 
   return (
-    <Form ref={form}>
+    <Form ref={form} className="admin-panel mt-8 grid gap-5 rounded-2xl p-6">
       <FieldContainer label="Name">
         <InputField
           type="text"
           name="name"
           defaultValue={props.category?.name ?? ""}
           required
+          disabled={props.category?.isSystem}
+          className="admin-input"
         />
       </FieldContainer>
 
@@ -95,9 +97,11 @@ export default function ClientForm(props: Readonly<ClientFormProps>) {
           name="parentId"
           value={parentId}
           onChange={(e) => setParentId(e.target.value)}
+          disabled={props.category?.isSystem}
+          className="admin-input"
         >
           <SelectOption value="">-- None --</SelectOption>
-          {categories.map((cat) => (
+          {props.categories.map((cat) => (
             <SelectOption key={cat.id} value={cat.id}>
               {cat.name}
             </SelectOption>
@@ -117,10 +121,10 @@ export default function ClientForm(props: Readonly<ClientFormProps>) {
         >
           Save
         </FormButton>
-        {props.isNew === false && (
+        {props.isNew === false && !props.category?.isSystem && (
           <FormButton
             type="button"
-            disabled={pending || props.hasChildCategories}
+            disabled={pending}
             className="text-btn-red border-btn-red"
             onClick={onDeleteClick}
           >

--- a/src/app/admin/money/categories/[id]/page.tsx
+++ b/src/app/admin/money/categories/[id]/page.tsx
@@ -1,20 +1,17 @@
 import { notFound } from "next/navigation";
-import Header1 from "@/components/Header1";
 import PageContainer from "@/components/PageContainer";
+import TopNavigator from "@/components/HomeButton";
 import ClientForm from "./components/ClientForm";
 import categoriesService from "@/services/categories.service";
 
 /**
- * Get all cetegories excluding the current category.
- * If currentId is provided, also exclude its child categories.
+ * Only top-level, non-system categories can be parents. This keeps the
+ * hierarchy to the two levels supported by the product.
  */
 const getCategories = async (currentId?: string) => {
-  const categories = currentId
-    ? await categoriesService.getNonChildCategories(currentId)
-    : await categoriesService.getAllCategories();
+  const categories = await categoriesService.getAvailableParents(currentId);
 
   return categories
-    .filter((cat) => cat.id !== currentId)
     .map((cat) => ({
       id: cat.id,
       name: cat.name,
@@ -22,7 +19,7 @@ const getCategories = async (currentId?: string) => {
 };
 
 export default async function CategoryPage(
-  props: Readonly<PageProps<"/admin/money/categories/[id]">>,
+  props: Readonly<{ params: Promise<{ id: string }> }>,
 ) {
   const { id } = await props.params;
   const isNew = id === "new";
@@ -31,22 +28,23 @@ export default async function CategoryPage(
 
   if (!isNew && !category) notFound();
 
-  const hasChildCategories = isNew
-    ? undefined
-    : await categoriesService.hasChildCategories(id);
-
   const categories = await getCategories(isNew ? undefined : id);
 
   return (
-    <PageContainer>
-      <Header1>A Category</Header1>
+    <main className="admin-shell min-h-screen">
+    <PageContainer className="mx-auto max-w-2xl">
+      <TopNavigator links={["home", "money"]} />
+      <p className="admin-eyebrow mt-10">Money settings</p>
+      <h1 className="mt-2 text-3xl font-semibold">
+        {isNew ? "New category" : category?.name}
+      </h1>
 
       <ClientForm
         category={category}
         isNew={isNew}
         categories={categories}
-        hasChildCategories={hasChildCategories}
       />
     </PageContainer>
+    </main>
   );
 }

--- a/src/app/admin/money/categories/[id]/page.tsx
+++ b/src/app/admin/money/categories/[id]/page.tsx
@@ -11,11 +11,10 @@ import categoriesService from "@/services/categories.service";
 const getCategories = async (currentId?: string) => {
   const categories = await categoriesService.getAvailableParents(currentId);
 
-  return categories
-    .map((cat) => ({
-      id: cat.id,
-      name: cat.name,
-    }));
+  return categories.map((cat) => ({
+    id: cat.id,
+    name: cat.name,
+  }));
 };
 
 export default async function CategoryPage(
@@ -32,19 +31,15 @@ export default async function CategoryPage(
 
   return (
     <main className="admin-shell min-h-screen">
-    <PageContainer className="mx-auto max-w-2xl">
-      <TopNavigator links={["home", "money"]} />
-      <p className="admin-eyebrow mt-10">Money settings</p>
-      <h1 className="mt-2 text-3xl font-semibold">
-        {isNew ? "New category" : category?.name}
-      </h1>
+      <PageContainer className="mx-auto max-w-2xl">
+        <TopNavigator links={["home", "money"]} />
+        <p className="admin-eyebrow mt-10">Money settings</p>
+        <h1 className="mt-2 text-3xl font-semibold">
+          {isNew ? "New category" : category?.name}
+        </h1>
 
-      <ClientForm
-        category={category}
-        isNew={isNew}
-        categories={categories}
-      />
-    </PageContainer>
+        <ClientForm category={category} isNew={isNew} categories={categories} />
+      </PageContainer>
     </main>
   );
 }

--- a/src/app/admin/money/categories/page.tsx
+++ b/src/app/admin/money/categories/page.tsx
@@ -1,33 +1,61 @@
 import FloatingAction from "@/components/FloatingAction";
-import Header1 from "@/components/Header1";
 import TopNavigator from "@/components/HomeButton";
 import PageContainer from "@/components/PageContainer";
-import { Category } from "@/generated/prisma/client";
+import categoriesService from "@/services/categories.service";
 import Link from "next/link";
+import { Route } from "next";
 
 export default async function CategoriesPage() {
-  // const categories = await categoriesService.getAllCategories();
-  const categories = [] as Category[];
+  const categories = await categoriesService.getAllCategories();
+  const roots = categories.filter((category) => !category.parentId);
 
   return (
-    <PageContainer className="grid grid-rows-[auto_1fr] gap-6 max-h-screen">
-      <TopNavigator links={["home", "money"]} />
+    <main className="admin-shell min-h-screen">
+      <PageContainer className="mx-auto max-w-4xl">
+        <TopNavigator links={["home", "money"]} />
+        <div className="mt-10 flex items-end justify-between gap-4">
+          <div>
+            <p className="admin-eyebrow">Organise transactions</p>
+            <h1 className="mt-2 text-3xl font-semibold">Categories</h1>
+          </div>
+          <span className="text-sm text-slate-400">{categories.length} total</span>
+        </div>
 
-      <Header1>Categories</Header1>
-
-      <div className="flex flex-col space-y-4 overflow-y-auto mb-4">
-        {categories.map((cat) => (
-          <Link
-            key={cat.id}
-            href={`/admin/money/categories/${cat.id}`}
-            className="p-4 border border-gray-200 rounded-md"
-          >
-            {cat.name}
-          </Link>
-        ))}
-      </div>
-
-      <FloatingAction href="/admin/money/categories/new">+</FloatingAction>
-    </PageContainer>
+        <div className="mt-8 grid gap-4 md:grid-cols-2">
+          {roots.map((category) => {
+            const children = categories.filter(
+              (candidate) => candidate.parentId === category.id,
+            );
+            return (
+              <section key={category.id} className="admin-panel rounded-2xl p-5">
+                <Link
+                  href={`/admin/money/categories/${category.id}`}
+                  className="flex items-center justify-between font-semibold hover:text-emerald-300"
+                >
+                  {category.name}
+                  {category.isSystem && (
+                    <span className="admin-badge">Default</span>
+                  )}
+                </Link>
+                {children.length > 0 && (
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {children.map((child) => (
+                      <Link
+                        key={child.id}
+                        href={`/admin/money/categories/${child.id}`}
+                        className="admin-chip"
+                      >
+                        {child.name}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </section>
+            );
+          })}
+        </div>
+        <FloatingAction href={"/admin/money/categories/new" as Route}>+</FloatingAction>
+      </PageContainer>
+    </main>
   );
 }

--- a/src/app/admin/money/page.tsx
+++ b/src/app/admin/money/page.tsx
@@ -5,7 +5,8 @@ import PageContainer from "@/components/PageContainer";
 
 export default function MoneyPage() {
   return (
-    <PageContainer className="grid grid-rows-[auto_1fr] items-center h-screen">
+    <main className="admin-shell min-h-screen">
+    <PageContainer className="mx-auto grid max-w-4xl grid-rows-[auto_auto_1fr] gap-8">
       <TopNavigator links={["home"]} />
 
       <Header1>Money</Header1>
@@ -13,7 +14,9 @@ export default function MoneyPage() {
       <div className="grid grid-cols-2 gap-4 items-center">
         <AppCard href="/admin/money/transactions">Transactions</AppCard>
         <AppCard href="/admin/money/categories">Categories</AppCard>
+        <AppCard href="/admin/money/settings">Opening Balance</AppCard>
       </div>
     </PageContainer>
+    </main>
   );
 }

--- a/src/app/admin/money/settings/BalanceForm.tsx
+++ b/src/app/admin/money/settings/BalanceForm.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useActionState } from "react";
+import { updateOpeningBalanceAction } from "./actions";
+
+export default function BalanceForm({ openingBalanceCents }: { openingBalanceCents: number }) {
+  const [state, action, pending] = useActionState(updateOpeningBalanceAction, {});
+  return (
+    <form action={action} className="admin-panel mt-8 grid gap-5 rounded-2xl p-6">
+      <label className="grid gap-2 text-sm font-medium">
+        Opening balance (SGD)
+        <input
+          className="admin-input"
+          name="openingBalance"
+          inputMode="decimal"
+          defaultValue={(openingBalanceCents / 100).toFixed(2)}
+          required
+        />
+      </label>
+      <p className="text-sm leading-6 text-slate-400">
+        This is the account balance immediately before your first recorded transaction. It may be negative.
+      </p>
+      {state.error && <p className="text-sm text-rose-300">{state.error}</p>}
+      {state.success && <p className="text-sm text-emerald-300">{state.success}</p>}
+      <button className="admin-primary-button justify-self-start" disabled={pending}>
+        {pending ? "Saving…" : "Save opening balance"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/money/settings/BalanceForm.tsx
+++ b/src/app/admin/money/settings/BalanceForm.tsx
@@ -3,10 +3,18 @@
 import { useActionState } from "react";
 import { updateOpeningBalanceAction } from "./actions";
 
-export default function BalanceForm({ openingBalanceCents }: { openingBalanceCents: number }) {
-  const [state, action, pending] = useActionState(updateOpeningBalanceAction, {});
+export default function BalanceForm({
+  openingBalanceCents,
+}: Readonly<{ openingBalanceCents: number }>) {
+  const [state, action, pending] = useActionState(
+    updateOpeningBalanceAction,
+    {},
+  );
   return (
-    <form action={action} className="admin-panel mt-8 grid gap-5 rounded-2xl p-6">
+    <form
+      action={action}
+      className="admin-panel mt-8 grid gap-5 rounded-2xl p-6"
+    >
       <label className="grid gap-2 text-sm font-medium">
         Opening balance (SGD)
         <input
@@ -18,11 +26,18 @@ export default function BalanceForm({ openingBalanceCents }: { openingBalanceCen
         />
       </label>
       <p className="text-sm leading-6 text-slate-400">
-        This is the account balance immediately before your first recorded transaction. It may be negative.
+        This is the account balance immediately before your first recorded
+        transaction. It may be negative.
       </p>
       {state.error && <p className="text-sm text-rose-300">{state.error}</p>}
-      {state.success && <p className="text-sm text-emerald-300">{state.success}</p>}
-      <button className="admin-primary-button justify-self-start" disabled={pending}>
+      {state.success && (
+        <p className="text-sm text-emerald-300">{state.success}</p>
+      )}
+      <button
+        type="submit"
+        className="admin-primary-button justify-self-start"
+        disabled={pending}
+      >
         {pending ? "Saving…" : "Save opening balance"}
       </button>
     </form>

--- a/src/app/admin/money/settings/actions.ts
+++ b/src/app/admin/money/settings/actions.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { parseMoneyToCents } from "@/features/money/money";
+import authService from "@/services/auth-service";
+import transactionsService from "@/services/transactions.service";
+import { revalidatePath } from "next/cache";
+
+export type BalanceState = { error?: string; success?: string };
+
+export const updateOpeningBalanceAction = async (
+  _previousState: BalanceState,
+  formData: FormData,
+): Promise<BalanceState> => {
+  await authService.requireAuthenticatedUser();
+  const value = formData.get("openingBalance");
+  if (typeof value !== "string") return { error: "Enter an opening balance." };
+
+  try {
+    await transactionsService.setOpeningBalanceCents(
+      parseMoneyToCents(value, true),
+    );
+    revalidatePath("/admin/money");
+    revalidatePath("/admin/money/transactions");
+    return { success: "Opening balance updated." };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : "Could not update balance." };
+  }
+};

--- a/src/app/admin/money/settings/page.tsx
+++ b/src/app/admin/money/settings/page.tsx
@@ -1,0 +1,18 @@
+import TopNavigator from "@/components/HomeButton";
+import PageContainer from "@/components/PageContainer";
+import transactionsService from "@/services/transactions.service";
+import BalanceForm from "./BalanceForm";
+
+export default async function MoneySettingsPage() {
+  const openingBalanceCents = await transactionsService.getOpeningBalanceCents();
+  return (
+    <main className="admin-shell min-h-screen">
+      <PageContainer className="mx-auto max-w-2xl">
+        <TopNavigator links={["home", "money"]} />
+        <p className="admin-eyebrow mt-10">Account setup</p>
+        <h1 className="mt-2 text-3xl font-semibold">Opening balance</h1>
+        <BalanceForm openingBalanceCents={openingBalanceCents} />
+      </PageContainer>
+    </main>
+  );
+}

--- a/src/app/admin/money/transactions/MoneyCharts.tsx
+++ b/src/app/admin/money/transactions/MoneyCharts.tsx
@@ -18,10 +18,10 @@ type CategoryPoint = { category: string; expense: number };
 export default function MoneyCharts({
   monthly,
   categories,
-}: {
+}: Readonly<{
   monthly: MonthlyPoint[];
   categories: CategoryPoint[];
-}) {
+}>) {
   return (
     <div className="grid gap-5 xl:grid-cols-2">
       <section className="admin-panel rounded-2xl p-5">
@@ -43,9 +43,29 @@ export default function MoneyCharts({
               <CartesianGrid stroke="rgba(148,163,184,.12)" vertical={false} />
               <XAxis dataKey="month" stroke="#94a3b8" fontSize={12} />
               <YAxis stroke="#94a3b8" fontSize={12} />
-              <Tooltip formatter={(value) => [`S$${Number(value ?? 0).toFixed(2)}`, ""]} contentStyle={{ background: "#0f1f1a", border: "1px solid rgba(148,163,184,.2)", borderRadius: 12 }} />
-              <Area type="monotone" dataKey="income" stroke="#34d399" fill="url(#income)" />
-              <Area type="monotone" dataKey="expense" stroke="#fb7185" fill="url(#expense)" />
+              <Tooltip
+                formatter={(value) => [
+                  `S$${Number(value ?? 0).toFixed(2)}`,
+                  "",
+                ]}
+                contentStyle={{
+                  background: "#0f1f1a",
+                  border: "1px solid rgba(148,163,184,.2)",
+                  borderRadius: 12,
+                }}
+              />
+              <Area
+                type="monotone"
+                dataKey="income"
+                stroke="#34d399"
+                fill="url(#income)"
+              />
+              <Area
+                type="monotone"
+                dataKey="expense"
+                stroke="#fb7185"
+                fill="url(#expense)"
+              />
             </AreaChart>
           </ResponsiveContainer>
         </div>
@@ -57,10 +77,29 @@ export default function MoneyCharts({
         <div className="mt-5 h-72">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={categories} layout="vertical" margin={{ left: 16 }}>
-              <CartesianGrid stroke="rgba(148,163,184,.12)" horizontal={false} />
+              <CartesianGrid
+                stroke="rgba(148,163,184,.12)"
+                horizontal={false}
+              />
               <XAxis type="number" stroke="#94a3b8" fontSize={12} />
-              <YAxis type="category" dataKey="category" width={90} stroke="#94a3b8" fontSize={12} />
-              <Tooltip formatter={(value) => [`S$${Number(value ?? 0).toFixed(2)}`, ""]} contentStyle={{ background: "#0f1f1a", border: "1px solid rgba(148,163,184,.2)", borderRadius: 12 }} />
+              <YAxis
+                type="category"
+                dataKey="category"
+                width={90}
+                stroke="#94a3b8"
+                fontSize={12}
+              />
+              <Tooltip
+                formatter={(value) => [
+                  `S$${Number(value ?? 0).toFixed(2)}`,
+                  "",
+                ]}
+                contentStyle={{
+                  background: "#0f1f1a",
+                  border: "1px solid rgba(148,163,184,.2)",
+                  borderRadius: 12,
+                }}
+              />
               <Bar dataKey="expense" fill="#fb7185" radius={[0, 6, 6, 0]} />
             </BarChart>
           </ResponsiveContainer>

--- a/src/app/admin/money/transactions/MoneyCharts.tsx
+++ b/src/app/admin/money/transactions/MoneyCharts.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+type MonthlyPoint = { month: string; income: number; expense: number };
+type CategoryPoint = { category: string; expense: number };
+
+export default function MoneyCharts({
+  monthly,
+  categories,
+}: {
+  monthly: MonthlyPoint[];
+  categories: CategoryPoint[];
+}) {
+  return (
+    <div className="grid gap-5 xl:grid-cols-2">
+      <section className="admin-panel rounded-2xl p-5">
+        <h2 className="font-semibold">Cash flow by month</h2>
+        <p className="mt-1 text-xs text-slate-400">Income versus expenses</p>
+        <div className="mt-5 h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={monthly}>
+              <defs>
+                <linearGradient id="income" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#34d399" stopOpacity={0.4} />
+                  <stop offset="95%" stopColor="#34d399" stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id="expense" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#fb7185" stopOpacity={0.35} />
+                  <stop offset="95%" stopColor="#fb7185" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid stroke="rgba(148,163,184,.12)" vertical={false} />
+              <XAxis dataKey="month" stroke="#94a3b8" fontSize={12} />
+              <YAxis stroke="#94a3b8" fontSize={12} />
+              <Tooltip formatter={(value) => [`S$${Number(value ?? 0).toFixed(2)}`, ""]} contentStyle={{ background: "#0f1f1a", border: "1px solid rgba(148,163,184,.2)", borderRadius: 12 }} />
+              <Area type="monotone" dataKey="income" stroke="#34d399" fill="url(#income)" />
+              <Area type="monotone" dataKey="expense" stroke="#fb7185" fill="url(#expense)" />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+
+      <section className="admin-panel rounded-2xl p-5">
+        <h2 className="font-semibold">Spending by category</h2>
+        <p className="mt-1 text-xs text-slate-400">Top expense categories</p>
+        <div className="mt-5 h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={categories} layout="vertical" margin={{ left: 16 }}>
+              <CartesianGrid stroke="rgba(148,163,184,.12)" horizontal={false} />
+              <XAxis type="number" stroke="#94a3b8" fontSize={12} />
+              <YAxis type="category" dataKey="category" width={90} stroke="#94a3b8" fontSize={12} />
+              <Tooltip formatter={(value) => [`S$${Number(value ?? 0).toFixed(2)}`, ""]} contentStyle={{ background: "#0f1f1a", border: "1px solid rgba(148,163,184,.2)", borderRadius: 12 }} />
+              <Bar dataKey="expense" fill="#fb7185" radius={[0, 6, 6, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/money/transactions/[id]/actions.ts
+++ b/src/app/admin/money/transactions/[id]/actions.ts
@@ -1,41 +1,57 @@
 "use server";
-import ts, { CreateTransactionDto } from "@/services/transactions.service";
-import { revalidatePath } from "next/cache";
 
-type FormEntries = {
-  [k in keyof Pick<
-    CreateTransactionDto,
-    "amount" | "title" | "comments" | "time"
-  >]: string;
+import { parseMoneyToCents } from "@/features/money/money";
+import authService from "@/services/auth-service";
+import transactionsService from "@/services/transactions.service";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+const transactionSchema = z.object({
+  amount: z.string().min(1),
+  direction: z.enum(["IN", "OUT"]),
+  title: z.string().trim().min(1).max(120),
+  comments: z.string().trim().max(500),
+  time: z.string().min(1),
+  categoryName: z.string().trim().max(80),
+});
+
+const parseEntries = (entries: Record<string, string>) => {
+  const parsed = transactionSchema.parse(entries);
+  const time = new Date(parsed.time);
+  if (Number.isNaN(time.getTime())) throw new Error("Choose a valid date and time.");
+  return {
+    amountCents: parseMoneyToCents(parsed.amount),
+    direction: parsed.direction,
+    title: parsed.title,
+    comments: parsed.comments || null,
+    time,
+    categoryName: parsed.categoryName,
+  };
 };
 
-export const createAction = async (entries: FormEntries) => {
-  console.log("time:", entries.time);
-  const created = await ts.create({
-    amount: Number.parseFloat(entries.amount),
-    title: entries.title,
-    comments: entries.comments || null,
-    time: new Date(entries.time),
-    categoryId: null,
-  });
-  revalidatePath("/admin/money/transactions");
-  revalidatePath(`/admin/money/transactions/${created.id}`);
+export const createAction = async (entries: Record<string, string>) => {
+  await authService.requireAuthenticatedUser();
+  const created = await transactionsService.create(parseEntries(entries));
+  revalidateMoney();
   return created.id;
 };
 
-export const updateAction = async (id: string, entries: FormEntries) => {
-  await ts.update(id, {
-    amount: Number.parseFloat(entries.amount),
-    title: entries.title,
-    comments: entries.comments || null,
-    time: new Date(entries.time),
-  });
-  revalidatePath("/admin/money/transactions");
-  revalidatePath(`/admin/money/transactions/${id}`);
+export const updateAction = async (
+  id: string,
+  entries: Record<string, string>,
+) => {
+  await authService.requireAuthenticatedUser();
+  await transactionsService.update(id, parseEntries(entries));
+  revalidateMoney();
 };
 
 export const deleteAction = async (id: string) => {
-  await ts.delete(id);
+  await authService.requireAuthenticatedUser();
+  await transactionsService.delete(id);
+  revalidateMoney();
+};
+
+const revalidateMoney = () => {
+  revalidatePath("/admin/money");
   revalidatePath("/admin/money/transactions");
-  revalidatePath(`/admin/money/transactions/${id}`);
 };

--- a/src/app/admin/money/transactions/[id]/components/ClientForm.tsx
+++ b/src/app/admin/money/transactions/[id]/components/ClientForm.tsx
@@ -1,134 +1,213 @@
 "use client";
-import { useRouter } from "next/navigation";
-import { MouseEventHandler, useRef, useState } from "react";
+
 import Form from "@/components/Form";
 import {
-  FieldContainer,
-  InputField,
-  FormButton,
-} from "@/components/FormFields";
-import { createAction, updateAction, deleteAction } from "../actions";
-import { Transaction } from "@/generated/prisma/browser";
-import {
-  buildFormEntries,
-  handleKnownExceptions,
-  toLocalISOString,
-  validateFormEntries,
-} from "../utils";
+  applyTransaction,
+  formatMoney,
+  MoneyDirection,
+  parseMoneyToCents,
+} from "@/features/money/money";
+import { useRouter } from "next/navigation";
+import { FormEvent, useMemo, useState } from "react";
+import { createAction, deleteAction, updateAction } from "../actions";
+import { toLocalISOString } from "../utils";
 
-type ClientFormProps = {
+type TransactionFormValue = {
+  id: string;
+  amountCents: number;
+  direction: MoneyDirection;
+  title: string;
+  comments: string | null;
+  time: Date;
+  categoryName: string;
+};
+
+type Props = {
   isNew: boolean;
-  transaction?: Transaction | null;
+  transaction?: TransactionFormValue | null;
+  categories: { id: string; name: string }[];
+  currentBalanceCents: number;
+  balanceWithoutTransactionCents: number;
 };
 
-const _onSaveClick = async (form: HTMLFormElement, id?: string) => {
-  const entries = buildFormEntries(form);
-  validateFormEntries(entries);
-
-  if (id) {
-    await updateAction(id, entries);
-  } else {
-    const createdId = await createAction(entries);
-    id = createdId;
-  }
-  return id;
-};
-
-export default function ClientForm(props: Readonly<ClientFormProps>) {
+export default function ClientForm(props: Readonly<Props>) {
   const router = useRouter();
-  const form = useRef<HTMLFormElement>(null);
   const [pending, setPending] = useState(false);
+  const [amount, setAmount] = useState(
+    props.transaction ? (props.transaction.amountCents / 100).toFixed(2) : "",
+  );
+  const [direction, setDirection] = useState<MoneyDirection>(
+    props.transaction?.direction ?? "OUT",
+  );
+  const [categoryName, setCategoryName] = useState(
+    props.transaction?.categoryName ?? "",
+  );
+  const [error, setError] = useState<string>();
 
-  const defaultTime = toLocalISOString(props.transaction?.time ?? new Date());
-
-  const onSaveClick: MouseEventHandler<HTMLButtonElement> = async (e) => {
-    if (!form.current!.checkValidity()) return;
-    e.preventDefault();
-    setPending(true);
+  const balanceAfterCents = useMemo(() => {
     try {
-      const id = await _onSaveClick(form.current!, props.transaction?.id);
-      if (props.isNew) router.push(`/admin/money/transactions/${id}`);
-    } catch (error) {
-      if (!handleKnownExceptions(error)) {
-        console.error("Failed to save transaction:", error);
-        alert("An error occurred while saving the transaction.");
-      }
+      const amountCents = amount ? parseMoneyToCents(amount) : 0;
+      return applyTransaction(
+        props.balanceWithoutTransactionCents,
+        amountCents,
+        direction,
+      );
+    } catch {
+      return props.balanceWithoutTransactionCents;
+    }
+  }, [amount, direction, props.balanceWithoutTransactionCents]);
+
+  const categoryExists = props.categories.some(
+    (category) => category.name.toLowerCase() === categoryName.trim().toLowerCase(),
+  );
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPending(true);
+    setError(undefined);
+    try {
+      const entries = Object.fromEntries(
+        new FormData(event.currentTarget).entries(),
+      ) as Record<string, string>;
+      const id = props.transaction?.id;
+      if (id) await updateAction(id, entries);
+      else router.push(`/admin/money/transactions/${await createAction(entries)}`);
+      router.refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not save transaction.");
     } finally {
       setPending(false);
     }
   };
 
-  const onDeleteClick: MouseEventHandler<HTMLButtonElement> = async (e) => {
-    e.preventDefault();
+  const onDelete = async () => {
+    if (!props.transaction || !confirm("Delete this transaction?")) return;
     setPending(true);
     try {
-      await deleteAction(props.transaction!.id);
+      await deleteAction(props.transaction.id);
       router.push("/admin/money/transactions");
-    } catch (error) {
-      console.error("Failed to delete transaction:", error);
-      alert("An error occurred while deleting the transaction.");
-    } finally {
+    } catch {
+      setError("Could not delete transaction.");
       setPending(false);
     }
   };
 
   return (
-    <Form ref={form} className="mt-10 grid grid-cols-1 gap-4">
-      <FieldContainer label="Amount">
-        <InputField
-          type="text"
-          name="amount"
-          required
-          defaultValue={props.transaction?.amount.toFixed(2)}
-        />
-      </FieldContainer>
-      <FieldContainer label="Title">
-        <InputField
-          type="text"
-          name="title"
-          required
-          defaultValue={props.transaction?.title}
-        />
-      </FieldContainer>
-      <FieldContainer label="Comments">
-        <InputField
-          type="text"
-          name="comments"
-          defaultValue={props.transaction?.comments || ""}
-        />
-      </FieldContainer>
-      <FieldContainer label="Time">
-        <InputField
-          type="datetime-local"
-          name="time"
-          required
-          defaultValue={defaultTime}
-        />
-      </FieldContainer>
-
-      <div className="flex justify-between mt-10">
-        <FormButton type="button" onClick={router.back} disabled={pending}>
-          Cancel
-        </FormButton>
-        <FormButton
-          type="submit"
-          className="text-btn-blue border-btn-blue"
-          onClick={onSaveClick}
-          disabled={pending}
-        >
-          Save
-        </FormButton>
-        {!props.isNew && (
-          <FormButton
-            type="submit"
-            className="text-btn-red border-btn-red"
-            onClick={onDeleteClick}
-            disabled={pending}
-          >
-            Delete
-          </FormButton>
-        )}
+    <>
+      <div className="mt-7 grid gap-3 sm:grid-cols-2">
+        <div className="admin-stat-card">
+          <span>Current balance</span>
+          <strong>{formatMoney(props.currentBalanceCents)}</strong>
+        </div>
+        <div className="admin-stat-card">
+          <span>Balance after save</span>
+          <strong className={balanceAfterCents < 0 ? "text-rose-300" : "text-emerald-300"}>
+            {formatMoney(balanceAfterCents)}
+          </strong>
+        </div>
       </div>
-    </Form>
+
+      <Form onSubmit={onSubmit} className="admin-panel mt-5 grid gap-5 rounded-2xl p-5 sm:p-7">
+        <div className="grid gap-5 sm:grid-cols-[1fr_9rem]">
+          <label className="grid gap-2 text-sm font-medium">
+            Amount (SGD)
+            <input
+              className="admin-input"
+              inputMode="decimal"
+              name="amount"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="0.00"
+              required
+            />
+          </label>
+          <label className="grid gap-2 text-sm font-medium">
+            Direction
+            <select
+              className="admin-input"
+              name="direction"
+              value={direction}
+              onChange={(event) => setDirection(event.target.value as MoneyDirection)}
+            >
+              <option value="OUT">Money out</option>
+              <option value="IN">Money in</option>
+            </select>
+          </label>
+        </div>
+
+        <label className="grid gap-2 text-sm font-medium">
+          Title
+          <input
+            className="admin-input"
+            name="title"
+            required
+            maxLength={120}
+            defaultValue={props.transaction?.title}
+            placeholder="Groceries, salary, rent…"
+          />
+        </label>
+
+        <label className="grid gap-2 text-sm font-medium">
+          Category
+          <input
+            className="admin-input"
+            name="categoryName"
+            list="category-options"
+            value={categoryName}
+            maxLength={80}
+            onChange={(event) => setCategoryName(event.target.value)}
+            placeholder="Unclassified"
+          />
+          <datalist id="category-options">
+            {props.categories.map((category) => (
+              <option key={category.id} value={category.name} />
+            ))}
+          </datalist>
+          {categoryName.trim() && !categoryExists && (
+            <span className="text-xs text-amber-200">
+              “{categoryName.trim()}” will be created as a top-level category.
+            </span>
+          )}
+        </label>
+
+        <label className="grid gap-2 text-sm font-medium">
+          Date and time
+          <input
+            className="admin-input"
+            type="datetime-local"
+            name="time"
+            required
+            defaultValue={toLocalISOString(props.transaction?.time ?? new Date())}
+          />
+        </label>
+
+        <label className="grid gap-2 text-sm font-medium">
+          Notes
+          <textarea
+            className="admin-input min-h-24 resize-y"
+            name="comments"
+            maxLength={500}
+            defaultValue={props.transaction?.comments ?? ""}
+          />
+        </label>
+
+        {error && <p role="alert" className="text-sm text-rose-300">{error}</p>}
+        <div className="flex flex-wrap justify-between gap-3 pt-2">
+          <button type="button" className="admin-secondary-button" onClick={() => router.back()}>
+            Cancel
+          </button>
+          <div className="flex gap-3">
+            {!props.isNew && (
+              <button type="button" className="admin-danger-button" onClick={onDelete} disabled={pending}>
+                Delete
+              </button>
+            )}
+            <button className="admin-primary-button" disabled={pending}>
+              {pending ? "Saving…" : "Save transaction"}
+            </button>
+          </div>
+        </div>
+      </Form>
+    </>
   );
 }

--- a/src/app/admin/money/transactions/[id]/components/ClientForm.tsx
+++ b/src/app/admin/money/transactions/[id]/components/ClientForm.tsx
@@ -8,7 +8,7 @@ import {
   parseMoneyToCents,
 } from "@/features/money/money";
 import { useRouter } from "next/navigation";
-import { FormEvent, useMemo, useState } from "react";
+import { SubmitEventHandler, useMemo, useState } from "react";
 import { createAction, deleteAction, updateAction } from "../actions";
 import { toLocalISOString } from "../utils";
 
@@ -58,10 +58,11 @@ export default function ClientForm(props: Readonly<Props>) {
   }, [amount, direction, props.balanceWithoutTransactionCents]);
 
   const categoryExists = props.categories.some(
-    (category) => category.name.toLowerCase() === categoryName.trim().toLowerCase(),
+    (category) =>
+      category.name.toLowerCase() === categoryName.trim().toLowerCase(),
   );
 
-  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const onSubmit: SubmitEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault();
     setPending(true);
     setError(undefined);
@@ -71,10 +72,13 @@ export default function ClientForm(props: Readonly<Props>) {
       ) as Record<string, string>;
       const id = props.transaction?.id;
       if (id) await updateAction(id, entries);
-      else router.push(`/admin/money/transactions/${await createAction(entries)}`);
+      else
+        router.push(`/admin/money/transactions/${await createAction(entries)}`);
       router.refresh();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Could not save transaction.");
+      setError(
+        cause instanceof Error ? cause.message : "Could not save transaction.",
+      );
     } finally {
       setPending(false);
     }
@@ -101,13 +105,20 @@ export default function ClientForm(props: Readonly<Props>) {
         </div>
         <div className="admin-stat-card">
           <span>Balance after save</span>
-          <strong className={balanceAfterCents < 0 ? "text-rose-300" : "text-emerald-300"}>
+          <strong
+            className={
+              balanceAfterCents < 0 ? "text-rose-300" : "text-emerald-300"
+            }
+          >
             {formatMoney(balanceAfterCents)}
           </strong>
         </div>
       </div>
 
-      <Form onSubmit={onSubmit} className="admin-panel mt-5 grid gap-5 rounded-2xl p-5 sm:p-7">
+      <Form
+        onSubmit={onSubmit}
+        className="admin-panel mt-5 grid gap-5 rounded-2xl p-5 sm:p-7"
+      >
         <div className="grid gap-5 sm:grid-cols-[1fr_9rem]">
           <label className="grid gap-2 text-sm font-medium">
             Amount (SGD)
@@ -127,7 +138,9 @@ export default function ClientForm(props: Readonly<Props>) {
               className="admin-input"
               name="direction"
               value={direction}
-              onChange={(event) => setDirection(event.target.value as MoneyDirection)}
+              onChange={(event) =>
+                setDirection(event.target.value as MoneyDirection)
+              }
             >
               <option value="OUT">Money out</option>
               <option value="IN">Money in</option>
@@ -177,7 +190,9 @@ export default function ClientForm(props: Readonly<Props>) {
             type="datetime-local"
             name="time"
             required
-            defaultValue={toLocalISOString(props.transaction?.time ?? new Date())}
+            defaultValue={toLocalISOString(
+              props.transaction?.time ?? new Date(),
+            )}
           />
         </label>
 
@@ -191,18 +206,35 @@ export default function ClientForm(props: Readonly<Props>) {
           />
         </label>
 
-        {error && <p role="alert" className="text-sm text-rose-300">{error}</p>}
+        {error && (
+          <p role="alert" className="text-sm text-rose-300">
+            {error}
+          </p>
+        )}
         <div className="flex flex-wrap justify-between gap-3 pt-2">
-          <button type="button" className="admin-secondary-button" onClick={() => router.back()}>
+          <button
+            type="button"
+            className="admin-secondary-button"
+            onClick={() => router.back()}
+          >
             Cancel
           </button>
           <div className="flex gap-3">
             {!props.isNew && (
-              <button type="button" className="admin-danger-button" onClick={onDelete} disabled={pending}>
+              <button
+                type="button"
+                className="admin-danger-button"
+                onClick={onDelete}
+                disabled={pending}
+              >
                 Delete
               </button>
             )}
-            <button className="admin-primary-button" disabled={pending}>
+            <button
+              type="submit"
+              className="admin-primary-button"
+              disabled={pending}
+            >
               {pending ? "Saving…" : "Save transaction"}
             </button>
           </div>

--- a/src/app/admin/money/transactions/[id]/page.tsx
+++ b/src/app/admin/money/transactions/[id]/page.tsx
@@ -1,22 +1,53 @@
-import Header1 from "@/components/Header1";
+import TopNavigator from "@/components/HomeButton";
 import PageContainer from "@/components/PageContainer";
+import categoriesService from "@/services/categories.service";
+import transactionsService from "@/services/transactions.service";
+import { notFound } from "next/navigation";
 import ClientForm from "./components/ClientForm";
-import ts from "@/services/transactions.service";
 
 export default async function TransactionPage(
-  props: Readonly<PageProps<"/admin/money/transactions/[id]">>,
+  props: Readonly<{ params: Promise<{ id: string }> }>,
 ) {
   const { id } = await props.params;
-
   const isNew = id === "new";
+  const transaction = isNew ? null : await transactionsService.getById(id);
+  if (!isNew && !transaction) notFound();
 
-  const transaction = isNew ? null : await ts.getById(id);
+  const [categories, currentBalanceCents, balanceWithoutTransactionCents] =
+    await Promise.all([
+      categoriesService.getAllCategories(),
+      transactionsService.getBalanceCents(),
+      transactionsService.getBalanceCents(transaction?.id),
+    ]);
 
   return (
-    <PageContainer className="px-5">
-      <Header1>A Transaction</Header1>
-
-      <ClientForm isNew={isNew} transaction={transaction} />
-    </PageContainer>
+    <main className="admin-shell min-h-screen pb-10">
+      <PageContainer className="mx-auto max-w-3xl px-5">
+        <TopNavigator links={["home", "money"]} />
+        <p className="admin-eyebrow mt-10">Ledger entry</p>
+        <h1 className="mt-2 text-3xl font-semibold">
+          {isNew ? "Add transaction" : "Edit transaction"}
+        </h1>
+        <ClientForm
+          isNew={isNew}
+          transaction={
+            transaction
+              ? {
+                  id: transaction.id,
+                  amountCents: transaction.amountCents,
+                  direction: transaction.direction,
+                  title: transaction.title,
+                  comments: transaction.comments,
+                  time: transaction.time,
+                  categoryName: transaction.category.name,
+                }
+              : null
+          }
+          categories={categories.map(({ id: categoryId, name }) => ({ id: categoryId, name }))}
+          currentBalanceCents={currentBalanceCents}
+          balanceWithoutTransactionCents={balanceWithoutTransactionCents}
+        />
+      </PageContainer>
+    </main>
   );
 }

--- a/src/app/admin/money/transactions/[id]/utils.ts
+++ b/src/app/admin/money/transactions/[id]/utils.ts
@@ -1,44 +1,4 @@
-import ValidationException from "@/exceptions/validation.exception";
-import { Transaction } from "@/generated/prisma/browser";
-
-type FormEntries = {
-  [k in keyof Pick<
-    Transaction,
-    "amount" | "title" | "comments" | "time"
-  >]: string;
-};
-
-export const handleKnownExceptions = (error: unknown) => {
-  let handled = false;
-
-  if (error instanceof ValidationException) {
-    alert(error.message);
-    handled = true;
-  }
-
-  return handled;
-};
-
-export const validateFormEntries = (entries: FormEntries) => {
-  if (Number.isNaN(Number.parseFloat(entries.amount)))
-    throw new ValidationException("Amount must be a valid number");
-};
-
-export const buildFormEntries = (form: HTMLFormElement): FormEntries => {
-  const formData = new FormData(form);
-  const entries = Object.fromEntries(formData.entries()) as FormEntries;
-
-  const time = new Date(entries.time);
-  entries.time = time.toISOString();
-
-  return entries;
-};
-
 export const toLocalISOString = (date: Date) => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  return `${year}-${month}-${day}T${hours}:${minutes}`;
+  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return localDate.toISOString().slice(0, 16);
 };

--- a/src/app/admin/money/transactions/components/Mobile.tsx
+++ b/src/app/admin/money/transactions/components/Mobile.tsx
@@ -1,0 +1,57 @@
+import { formatMoney } from "@/features/money/money";
+import transactionsService from "@/services/transactions.service";
+import Link from "next/link";
+
+type RowTransaction = Awaited<
+  ReturnType<typeof transactionsService.getAll>
+>[number];
+
+export function TransactionRow({
+  transaction,
+}: Readonly<{ transaction: RowTransaction }>) {
+  return (
+    <Link
+      href={`/admin/money/transactions/${transaction.id}`}
+      className="grid grid-cols-[1.6fr_.8fr_.8fr_.8fr] gap-4 border-b border-white/5 px-5 py-4 text-sm hover:bg-white/5"
+    >
+      <span className="font-medium">{transaction.title}</span>
+      <span className="text-slate-400">{transaction.category.name}</span>
+      <span className="text-slate-400">
+        {transaction.time.toLocaleDateString("en-SG")}
+      </span>
+      <span
+        className={`text-right font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}
+      >
+        {transaction.direction === "IN" ? "+" : "−"}
+        {formatMoney(transaction.amountCents)}
+      </span>
+    </Link>
+  );
+}
+
+export function MobileTransaction({
+  transaction,
+}: Readonly<{ transaction: RowTransaction }>) {
+  return (
+    <Link
+      href={`/admin/money/transactions/${transaction.id}`}
+      className="flex items-center justify-between gap-4 px-4 py-4"
+    >
+      <div className="min-w-0">
+        <p className="truncate font-medium">{transaction.title}</p>
+        <p className="mt-1 text-xs text-slate-500">
+          {transaction.time.toLocaleString("en-SG", {
+            dateStyle: "medium",
+            timeStyle: "short",
+          })}
+        </p>
+      </div>
+      <span
+        className={`shrink-0 font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}
+      >
+        {transaction.direction === "IN" ? "+" : "−"}
+        {formatMoney(transaction.amountCents)}
+      </span>
+    </Link>
+  );
+}

--- a/src/app/admin/money/transactions/components/Stat.tsx
+++ b/src/app/admin/money/transactions/components/Stat.tsx
@@ -1,0 +1,25 @@
+import cn from "classnames";
+
+export default function Stat({
+  label,
+  value,
+  tone,
+}: Readonly<{
+  label: string;
+  value: string;
+  tone?: "positive" | "negative";
+}>) {
+  return (
+    <div className="admin-stat-card">
+      <span>{label}</span>
+      <strong
+        className={cn({
+          "text-emerald-300": tone === "positive",
+          "text-rose-300": tone === "negative",
+        })}
+      >
+        {value}
+      </strong>
+    </div>
+  );
+}

--- a/src/app/admin/money/transactions/page.tsx
+++ b/src/app/admin/money/transactions/page.tsx
@@ -1,4 +1,3 @@
-import cn from "classnames";
 import FloatingAction from "@/components/FloatingAction";
 import TopNavigator from "@/components/HomeButton";
 import PageContainer from "@/components/PageContainer";
@@ -10,6 +9,8 @@ import transactionsService, {
 import Link from "next/link";
 import { Route } from "next";
 import MoneyCharts from "./MoneyCharts";
+import Stat from "./components/Stat";
+import { MobileTransaction, TransactionRow } from "./components/Mobile";
 
 const PAGE_SIZE = 12;
 type SearchParams = Record<string, string | string[] | undefined>;
@@ -244,82 +245,5 @@ export default async function TransactionsPage({
         </FloatingAction>
       </PageContainer>
     </main>
-  );
-}
-
-function Stat({
-  label,
-  value,
-  tone,
-}: Readonly<{
-  label: string;
-  value: string;
-  tone?: "positive" | "negative";
-}>) {
-  return (
-    <div className="admin-stat-card">
-      <span>{label}</span>
-      <strong
-        className={cn({
-          "text-emerald-300": tone === "positive",
-          "text-rose-300": tone === "negative",
-        })}
-      >
-        {value}
-      </strong>
-    </div>
-  );
-}
-
-type RowTransaction = Awaited<
-  ReturnType<typeof transactionsService.getAll>
->[number];
-function TransactionRow({
-  transaction,
-}: Readonly<{ transaction: RowTransaction }>) {
-  return (
-    <Link
-      href={`/admin/money/transactions/${transaction.id}`}
-      className="grid grid-cols-[1.6fr_.8fr_.8fr_.8fr] gap-4 border-b border-white/5 px-5 py-4 text-sm hover:bg-white/5"
-    >
-      <span className="font-medium">{transaction.title}</span>
-      <span className="text-slate-400">{transaction.category.name}</span>
-      <span className="text-slate-400">
-        {transaction.time.toLocaleDateString("en-SG")}
-      </span>
-      <span
-        className={`text-right font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}
-      >
-        {transaction.direction === "IN" ? "+" : "−"}
-        {formatMoney(transaction.amountCents)}
-      </span>
-    </Link>
-  );
-}
-
-function MobileTransaction({
-  transaction,
-}: Readonly<{ transaction: RowTransaction }>) {
-  return (
-    <Link
-      href={`/admin/money/transactions/${transaction.id}`}
-      className="flex items-center justify-between gap-4 px-4 py-4"
-    >
-      <div className="min-w-0">
-        <p className="truncate font-medium">{transaction.title}</p>
-        <p className="mt-1 text-xs text-slate-500">
-          {transaction.time.toLocaleString("en-SG", {
-            dateStyle: "medium",
-            timeStyle: "short",
-          })}
-        </p>
-      </div>
-      <span
-        className={`shrink-0 font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}
-      >
-        {transaction.direction === "IN" ? "+" : "−"}
-        {formatMoney(transaction.amountCents)}
-      </span>
-    </Link>
   );
 }

--- a/src/app/admin/money/transactions/page.tsx
+++ b/src/app/admin/money/transactions/page.tsx
@@ -1,33 +1,180 @@
 import FloatingAction from "@/components/FloatingAction";
-import Header1 from "@/components/Header1";
 import TopNavigator from "@/components/HomeButton";
 import PageContainer from "@/components/PageContainer";
-import { Transaction } from "@/generated/prisma/client";
+import { formatMoney } from "@/features/money/money";
+import categoriesService from "@/services/categories.service";
+import transactionsService, {
+  TransactionFilters,
+} from "@/services/transactions.service";
 import Link from "next/link";
+import { Route } from "next";
+import MoneyCharts from "./MoneyCharts";
 
-export default async function MoneyPage() {
-  const transactions = [] as Transaction[]; // await ts.getAll();
+const PAGE_SIZE = 12;
+type SearchParams = Record<string, string | string[] | undefined>;
+
+const first = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] : value;
+
+const dateAt = (value: string | undefined, endOfDay = false) => {
+  if (!value) return undefined;
+  const date = new Date(`${value}T${endOfDay ? "23:59:59.999" : "00:00:00"}`);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+};
+
+export default async function TransactionsPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const query = await searchParams;
+  const page = Math.max(1, Number.parseInt(first(query.page) ?? "1", 10) || 1);
+  const direction = first(query.direction);
+  const filters: TransactionFilters = {
+    categoryId: first(query.category),
+    direction: direction === "IN" || direction === "OUT" ? direction : undefined,
+    from: dateAt(first(query.from)),
+    to: dateAt(first(query.to), true),
+    search: first(query.search),
+  };
+
+  const [transactions, categories, balanceCents] = await Promise.all([
+    transactionsService.getAll(filters),
+    categoriesService.getAllCategories(),
+    transactionsService.getBalanceCents(),
+  ]);
+  const totalPages = Math.max(1, Math.ceil(transactions.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const descendingPage = transactions.slice(
+    (safePage - 1) * PAGE_SIZE,
+    safePage * PAGE_SIZE,
+  );
+  const ascendingPage = [...transactions]
+    .reverse()
+    .slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  const incomeCents = transactions
+    .filter((transaction) => transaction.direction === "IN")
+    .reduce((sum, transaction) => sum + transaction.amountCents, 0);
+  const expenseCents = transactions
+    .filter((transaction) => transaction.direction === "OUT")
+    .reduce((sum, transaction) => sum + transaction.amountCents, 0);
+
+  const monthlyMap = new Map<string, { income: number; expense: number }>();
+  const categoryMap = new Map<string, number>();
+  for (const transaction of transactions) {
+    const month = transaction.time.toLocaleDateString("en-SG", {
+      month: "short",
+      year: "2-digit",
+    });
+    const monthly = monthlyMap.get(month) ?? { income: 0, expense: 0 };
+    monthly[transaction.direction === "IN" ? "income" : "expense"] +=
+      transaction.amountCents / 100;
+    monthlyMap.set(month, monthly);
+    if (transaction.direction === "OUT") {
+      categoryMap.set(
+        transaction.category.name,
+        (categoryMap.get(transaction.category.name) ?? 0) +
+          transaction.amountCents / 100,
+      );
+    }
+  }
+  const monthly = [...monthlyMap.entries()]
+    .reverse()
+    .slice(-12)
+    .map(([month, values]) => ({ month, ...values }));
+  const categoryChart = [...categoryMap.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([category, expense]) => ({ category, expense }));
+
+  const pageHref = (targetPage: number) => {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (key !== "page" && typeof value === "string" && value) params.set(key, value);
+    }
+    params.set("page", String(targetPage));
+    return `/admin/money/transactions?${params}` as Route;
+  };
 
   return (
-    <PageContainer className="grid grid-rows-[auto_1fr] gap-6 max-h-screen">
-      <TopNavigator links={["home", "money"]} />
-
-      <Header1>Transactions</Header1>
-
-      <div className="flex flex-col space-y-4 overflow-y-auto mb-4">
-        {transactions.map((t) => (
-          <Link
-            key={t.id}
-            href={`/admin/money/transactions/${t.id}`}
-            className="p-4 border border-gray-200 rounded-md flex justify-between"
-          >
-            <span>{t.title}</span>
-            <span>{t.amount.toFixed(2)}</span>
+    <main className="admin-shell min-h-screen pb-16">
+      <PageContainer className="mx-auto max-w-7xl">
+        <TopNavigator links={["home", "money"]} />
+        <div className="mt-8 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="admin-eyebrow">SGD ledger</p>
+            <h1 className="mt-2 text-3xl font-semibold">Transactions</h1>
+          </div>
+          <Link href="/admin/money/settings" className="admin-secondary-button hidden md:inline-flex">
+            Opening balance
           </Link>
-        ))}
-      </div>
+        </div>
 
-      <FloatingAction href="/admin/money/transactions/new">+</FloatingAction>
-    </PageContainer>
+        <section className="mt-7 hidden gap-4 md:grid md:grid-cols-4">
+          <Stat label="Current balance" value={formatMoney(balanceCents)} />
+          <Stat label="Filtered income" value={formatMoney(incomeCents)} tone="positive" />
+          <Stat label="Filtered spending" value={formatMoney(expenseCents)} tone="negative" />
+          <Stat label="Filtered net" value={formatMoney(incomeCents - expenseCents)} />
+        </section>
+
+        <form className="admin-panel mt-5 hidden gap-4 rounded-2xl p-5 md:grid lg:grid-cols-6">
+          <input className="admin-input lg:col-span-2" name="search" placeholder="Search title" defaultValue={first(query.search)} />
+          <select className="admin-input" name="category" defaultValue={first(query.category) ?? ""}>
+            <option value="">All categories</option>
+            {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+          </select>
+          <select className="admin-input" name="direction" defaultValue={direction ?? ""}>
+            <option value="">In and out</option>
+            <option value="IN">Money in</option>
+            <option value="OUT">Money out</option>
+          </select>
+          <input className="admin-input" type="date" name="from" aria-label="From date" defaultValue={first(query.from)} />
+          <input className="admin-input" type="date" name="to" aria-label="To date" defaultValue={first(query.to)} />
+          <div className="flex gap-3 lg:col-span-6">
+            <button className="admin-primary-button">Apply filters</button>
+            <Link href="/admin/money/transactions" className="admin-secondary-button">Clear</Link>
+          </div>
+        </form>
+
+        <div className="mt-5 hidden md:block">
+          <MoneyCharts monthly={monthly} categories={categoryChart} />
+        </div>
+
+        <section className="admin-panel mt-5 overflow-hidden rounded-2xl">
+          <div className="hidden grid-cols-[1.6fr_.8fr_.8fr_.8fr] gap-4 border-b border-white/10 px-5 py-3 text-xs uppercase tracking-wider text-slate-500 md:grid">
+            <span>Transaction</span><span>Category</span><span>Date</span><span className="text-right">Amount</span>
+          </div>
+          <div className="hidden md:block">
+            {descendingPage.map((transaction) => <TransactionRow key={transaction.id} transaction={transaction} />)}
+          </div>
+          <div className="divide-y divide-white/10 md:hidden">
+            {ascendingPage.map((transaction) => <MobileTransaction key={transaction.id} transaction={transaction} />)}
+          </div>
+          {transactions.length === 0 && <p className="p-8 text-center text-sm text-slate-400">No transactions match these filters.</p>}
+        </section>
+
+        <div className="mt-5 flex items-center justify-between text-sm">
+          <Link className={`admin-secondary-button ${safePage === 1 ? "pointer-events-none opacity-40" : ""}`} href={pageHref(Math.max(1, safePage - 1))}>Previous</Link>
+          <span className="text-slate-400">Page {safePage} of {totalPages}</span>
+          <Link className={`admin-secondary-button ${safePage === totalPages ? "pointer-events-none opacity-40" : ""}`} href={pageHref(Math.min(totalPages, safePage + 1))}>Next</Link>
+        </div>
+
+        <FloatingAction href={"/admin/money/transactions/new" as Route}>+</FloatingAction>
+      </PageContainer>
+    </main>
   );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: "positive" | "negative" }) {
+  return <div className="admin-stat-card"><span>{label}</span><strong className={tone === "positive" ? "text-emerald-300" : tone === "negative" ? "text-rose-300" : ""}>{value}</strong></div>;
+}
+
+type RowTransaction = Awaited<ReturnType<typeof transactionsService.getAll>>[number];
+function TransactionRow({ transaction }: { transaction: RowTransaction }) {
+  return <Link href={`/admin/money/transactions/${transaction.id}`} className="grid grid-cols-[1.6fr_.8fr_.8fr_.8fr] gap-4 border-b border-white/5 px-5 py-4 text-sm hover:bg-white/5"><span className="font-medium">{transaction.title}</span><span className="text-slate-400">{transaction.category.name}</span><span className="text-slate-400">{transaction.time.toLocaleDateString("en-SG")}</span><span className={`text-right font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}>{transaction.direction === "IN" ? "+" : "−"}{formatMoney(transaction.amountCents)}</span></Link>;
+}
+
+function MobileTransaction({ transaction }: { transaction: RowTransaction }) {
+  return <Link href={`/admin/money/transactions/${transaction.id}`} className="flex items-center justify-between gap-4 px-4 py-4"><div className="min-w-0"><p className="truncate font-medium">{transaction.title}</p><p className="mt-1 text-xs text-slate-500">{transaction.time.toLocaleString("en-SG", { dateStyle: "medium", timeStyle: "short" })}</p></div><span className={`shrink-0 font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}>{transaction.direction === "IN" ? "+" : "−"}{formatMoney(transaction.amountCents)}</span></Link>;
 }

--- a/src/app/admin/money/transactions/page.tsx
+++ b/src/app/admin/money/transactions/page.tsx
@@ -1,3 +1,4 @@
+import cn from "classnames";
 import FloatingAction from "@/components/FloatingAction";
 import TopNavigator from "@/components/HomeButton";
 import PageContainer from "@/components/PageContainer";
@@ -24,15 +25,16 @@ const dateAt = (value: string | undefined, endOfDay = false) => {
 
 export default async function TransactionsPage({
   searchParams,
-}: {
+}: Readonly<{
   searchParams: Promise<SearchParams>;
-}) {
+}>) {
   const query = await searchParams;
   const page = Math.max(1, Number.parseInt(first(query.page) ?? "1", 10) || 1);
   const direction = first(query.direction);
   const filters: TransactionFilters = {
     categoryId: first(query.category),
-    direction: direction === "IN" || direction === "OUT" ? direction : undefined,
+    direction:
+      direction === "IN" || direction === "OUT" ? direction : undefined,
     from: dateAt(first(query.from)),
     to: dateAt(first(query.to), true),
     search: first(query.search),
@@ -91,7 +93,8 @@ export default async function TransactionsPage({
   const pageHref = (targetPage: number) => {
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(query)) {
-      if (key !== "page" && typeof value === "string" && value) params.set(key, value);
+      if (key !== "page" && typeof value === "string" && value)
+        params.set(key, value);
     }
     params.set("page", String(targetPage));
     return `/admin/money/transactions?${params}` as Route;
@@ -106,34 +109,84 @@ export default async function TransactionsPage({
             <p className="admin-eyebrow">SGD ledger</p>
             <h1 className="mt-2 text-3xl font-semibold">Transactions</h1>
           </div>
-          <Link href="/admin/money/settings" className="admin-secondary-button hidden md:inline-flex">
+          <Link
+            href="/admin/money/settings"
+            className="admin-secondary-button hidden md:inline-flex"
+          >
             Opening balance
           </Link>
         </div>
 
         <section className="mt-7 hidden gap-4 md:grid md:grid-cols-4">
           <Stat label="Current balance" value={formatMoney(balanceCents)} />
-          <Stat label="Filtered income" value={formatMoney(incomeCents)} tone="positive" />
-          <Stat label="Filtered spending" value={formatMoney(expenseCents)} tone="negative" />
-          <Stat label="Filtered net" value={formatMoney(incomeCents - expenseCents)} />
+          <Stat
+            label="Filtered income"
+            value={formatMoney(incomeCents)}
+            tone="positive"
+          />
+          <Stat
+            label="Filtered spending"
+            value={formatMoney(expenseCents)}
+            tone="negative"
+          />
+          <Stat
+            label="Filtered net"
+            value={formatMoney(incomeCents - expenseCents)}
+          />
         </section>
 
         <form className="admin-panel mt-5 hidden gap-4 rounded-2xl p-5 md:grid lg:grid-cols-6">
-          <input className="admin-input lg:col-span-2" name="search" placeholder="Search title" defaultValue={first(query.search)} />
-          <select className="admin-input" name="category" defaultValue={first(query.category) ?? ""}>
+          <input
+            className="admin-input lg:col-span-2"
+            name="search"
+            placeholder="Search title"
+            defaultValue={first(query.search)}
+          />
+          <select
+            className="admin-input"
+            name="category"
+            defaultValue={first(query.category) ?? ""}
+          >
             <option value="">All categories</option>
-            {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
           </select>
-          <select className="admin-input" name="direction" defaultValue={direction ?? ""}>
+          <select
+            className="admin-input"
+            name="direction"
+            defaultValue={direction ?? ""}
+          >
             <option value="">In and out</option>
             <option value="IN">Money in</option>
             <option value="OUT">Money out</option>
           </select>
-          <input className="admin-input" type="date" name="from" aria-label="From date" defaultValue={first(query.from)} />
-          <input className="admin-input" type="date" name="to" aria-label="To date" defaultValue={first(query.to)} />
+          <input
+            className="admin-input"
+            type="date"
+            name="from"
+            aria-label="From date"
+            defaultValue={first(query.from)}
+          />
+          <input
+            className="admin-input"
+            type="date"
+            name="to"
+            aria-label="To date"
+            defaultValue={first(query.to)}
+          />
           <div className="flex gap-3 lg:col-span-6">
-            <button className="admin-primary-button">Apply filters</button>
-            <Link href="/admin/money/transactions" className="admin-secondary-button">Clear</Link>
+            <button type="submit" className="admin-primary-button">
+              Apply filters
+            </button>
+            <Link
+              href="/admin/money/transactions"
+              className="admin-secondary-button"
+            >
+              Clear
+            </Link>
           </div>
         </form>
 
@@ -143,38 +196,130 @@ export default async function TransactionsPage({
 
         <section className="admin-panel mt-5 overflow-hidden rounded-2xl">
           <div className="hidden grid-cols-[1.6fr_.8fr_.8fr_.8fr] gap-4 border-b border-white/10 px-5 py-3 text-xs uppercase tracking-wider text-slate-500 md:grid">
-            <span>Transaction</span><span>Category</span><span>Date</span><span className="text-right">Amount</span>
+            <span>Transaction</span>
+            <span>Category</span>
+            <span>Date</span>
+            <span className="text-right">Amount</span>
           </div>
           <div className="hidden md:block">
-            {descendingPage.map((transaction) => <TransactionRow key={transaction.id} transaction={transaction} />)}
+            {descendingPage.map((transaction) => (
+              <TransactionRow key={transaction.id} transaction={transaction} />
+            ))}
           </div>
           <div className="divide-y divide-white/10 md:hidden">
-            {ascendingPage.map((transaction) => <MobileTransaction key={transaction.id} transaction={transaction} />)}
+            {ascendingPage.map((transaction) => (
+              <MobileTransaction
+                key={transaction.id}
+                transaction={transaction}
+              />
+            ))}
           </div>
-          {transactions.length === 0 && <p className="p-8 text-center text-sm text-slate-400">No transactions match these filters.</p>}
+          {transactions.length === 0 && (
+            <p className="p-8 text-center text-sm text-slate-400">
+              No transactions match these filters.
+            </p>
+          )}
         </section>
 
         <div className="mt-5 flex items-center justify-between text-sm">
-          <Link className={`admin-secondary-button ${safePage === 1 ? "pointer-events-none opacity-40" : ""}`} href={pageHref(Math.max(1, safePage - 1))}>Previous</Link>
-          <span className="text-slate-400">Page {safePage} of {totalPages}</span>
-          <Link className={`admin-secondary-button ${safePage === totalPages ? "pointer-events-none opacity-40" : ""}`} href={pageHref(Math.min(totalPages, safePage + 1))}>Next</Link>
+          <Link
+            className={`admin-secondary-button ${safePage === 1 ? "pointer-events-none opacity-40" : ""}`}
+            href={pageHref(Math.max(1, safePage - 1))}
+          >
+            Previous
+          </Link>
+          <span className="text-slate-400">
+            Page {safePage} of {totalPages}
+          </span>
+          <Link
+            className={`admin-secondary-button ${safePage === totalPages ? "pointer-events-none opacity-40" : ""}`}
+            href={pageHref(Math.min(totalPages, safePage + 1))}
+          >
+            Next
+          </Link>
         </div>
 
-        <FloatingAction href={"/admin/money/transactions/new" as Route}>+</FloatingAction>
+        <FloatingAction href={"/admin/money/transactions/new" as Route}>
+          +
+        </FloatingAction>
       </PageContainer>
     </main>
   );
 }
 
-function Stat({ label, value, tone }: { label: string; value: string; tone?: "positive" | "negative" }) {
-  return <div className="admin-stat-card"><span>{label}</span><strong className={tone === "positive" ? "text-emerald-300" : tone === "negative" ? "text-rose-300" : ""}>{value}</strong></div>;
+function Stat({
+  label,
+  value,
+  tone,
+}: Readonly<{
+  label: string;
+  value: string;
+  tone?: "positive" | "negative";
+}>) {
+  return (
+    <div className="admin-stat-card">
+      <span>{label}</span>
+      <strong
+        className={cn({
+          "text-emerald-300": tone === "positive",
+          "text-rose-300": tone === "negative",
+        })}
+      >
+        {value}
+      </strong>
+    </div>
+  );
 }
 
-type RowTransaction = Awaited<ReturnType<typeof transactionsService.getAll>>[number];
-function TransactionRow({ transaction }: { transaction: RowTransaction }) {
-  return <Link href={`/admin/money/transactions/${transaction.id}`} className="grid grid-cols-[1.6fr_.8fr_.8fr_.8fr] gap-4 border-b border-white/5 px-5 py-4 text-sm hover:bg-white/5"><span className="font-medium">{transaction.title}</span><span className="text-slate-400">{transaction.category.name}</span><span className="text-slate-400">{transaction.time.toLocaleDateString("en-SG")}</span><span className={`text-right font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}>{transaction.direction === "IN" ? "+" : "−"}{formatMoney(transaction.amountCents)}</span></Link>;
+type RowTransaction = Awaited<
+  ReturnType<typeof transactionsService.getAll>
+>[number];
+function TransactionRow({
+  transaction,
+}: Readonly<{ transaction: RowTransaction }>) {
+  return (
+    <Link
+      href={`/admin/money/transactions/${transaction.id}`}
+      className="grid grid-cols-[1.6fr_.8fr_.8fr_.8fr] gap-4 border-b border-white/5 px-5 py-4 text-sm hover:bg-white/5"
+    >
+      <span className="font-medium">{transaction.title}</span>
+      <span className="text-slate-400">{transaction.category.name}</span>
+      <span className="text-slate-400">
+        {transaction.time.toLocaleDateString("en-SG")}
+      </span>
+      <span
+        className={`text-right font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}
+      >
+        {transaction.direction === "IN" ? "+" : "−"}
+        {formatMoney(transaction.amountCents)}
+      </span>
+    </Link>
+  );
 }
 
-function MobileTransaction({ transaction }: { transaction: RowTransaction }) {
-  return <Link href={`/admin/money/transactions/${transaction.id}`} className="flex items-center justify-between gap-4 px-4 py-4"><div className="min-w-0"><p className="truncate font-medium">{transaction.title}</p><p className="mt-1 text-xs text-slate-500">{transaction.time.toLocaleString("en-SG", { dateStyle: "medium", timeStyle: "short" })}</p></div><span className={`shrink-0 font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}>{transaction.direction === "IN" ? "+" : "−"}{formatMoney(transaction.amountCents)}</span></Link>;
+function MobileTransaction({
+  transaction,
+}: Readonly<{ transaction: RowTransaction }>) {
+  return (
+    <Link
+      href={`/admin/money/transactions/${transaction.id}`}
+      className="flex items-center justify-between gap-4 px-4 py-4"
+    >
+      <div className="min-w-0">
+        <p className="truncate font-medium">{transaction.title}</p>
+        <p className="mt-1 text-xs text-slate-500">
+          {transaction.time.toLocaleString("en-SG", {
+            dateStyle: "medium",
+            timeStyle: "short",
+          })}
+        </p>
+      </div>
+      <span
+        className={`shrink-0 font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}
+      >
+        {transaction.direction === "IN" ? "+" : "−"}
+        {formatMoney(transaction.amountCents)}
+      </span>
+    </Link>
+  );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,17 +1,19 @@
 import PageContainer from "@/components/PageContainer";
 import Header1 from "@/components/Header1";
 import AppCard from "@/components/AppCard";
+import TopNavigator from "@/components/HomeButton";
 
 export default async function AdminPage() {
   return (
-    <PageContainer className="grid grid-rows-[auto_1fr] items-center h-screen">
+    <PageContainer className="admin-shell grid min-h-screen grid-rows-[auto_auto_1fr] gap-8">
+      <TopNavigator links={[]} />
       <Header1>Apps</Header1>
 
       <div className="grid grid-cols-2 gap-4 items-center">
         <AppCard href="/admin/stocks-calculator">Stocks Calculator</AppCard>
         <AppCard href="/admin/rent-rooms">Rent Rooms</AppCard>
         <AppCard href="/admin/money">Money</AppCard>
-        <AppCard href="/admin">Comming Soon</AppCard>
+        <AppCard href="/admin/profile">Profile</AppCard>
       </div>
     </PageContainer>
   );

--- a/src/app/admin/profile/ProfileForm.tsx
+++ b/src/app/admin/profile/ProfileForm.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useActionState } from "react";
+import { updateProfileAction } from "./actions";
+
+export default function ProfileForm({ username }: { username: string }) {
+  const [state, action, pending] = useActionState(updateProfileAction, {});
+
+  return (
+    <form action={action} className="admin-panel mt-8 grid gap-5 rounded-2xl p-6">
+      <label className="grid gap-2 text-sm font-medium">
+        Username
+        <input
+          className="admin-input"
+          name="username"
+          defaultValue={username}
+          required
+          minLength={3}
+          maxLength={80}
+          autoComplete="username"
+        />
+      </label>
+      <label className="grid gap-2 text-sm font-medium">
+        Current password
+        <input
+          className="admin-input"
+          type="password"
+          name="currentPassword"
+          required
+          autoComplete="current-password"
+        />
+      </label>
+      <div className="grid gap-5 md:grid-cols-2">
+        <label className="grid gap-2 text-sm font-medium">
+          New password
+          <input
+            className="admin-input"
+            type="password"
+            name="newPassword"
+            minLength={12}
+            autoComplete="new-password"
+            placeholder="Leave blank to keep it"
+          />
+        </label>
+        <label className="grid gap-2 text-sm font-medium">
+          Confirm new password
+          <input
+            className="admin-input"
+            type="password"
+            name="confirmPassword"
+            autoComplete="new-password"
+          />
+        </label>
+      </div>
+      {state.error && <p className="text-sm text-rose-300">{state.error}</p>}
+      {state.success && <p className="text-sm text-emerald-300">{state.success}</p>}
+      <button className="admin-primary-button justify-self-start" disabled={pending}>
+        {pending ? "Saving…" : "Save profile"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/profile/ProfileForm.tsx
+++ b/src/app/admin/profile/ProfileForm.tsx
@@ -3,11 +3,16 @@
 import { useActionState } from "react";
 import { updateProfileAction } from "./actions";
 
-export default function ProfileForm({ username }: { username: string }) {
+export default function ProfileForm({
+  username,
+}: Readonly<{ username: string }>) {
   const [state, action, pending] = useActionState(updateProfileAction, {});
 
   return (
-    <form action={action} className="admin-panel mt-8 grid gap-5 rounded-2xl p-6">
+    <form
+      action={action}
+      className="admin-panel mt-8 grid gap-5 rounded-2xl p-6"
+    >
       <label className="grid gap-2 text-sm font-medium">
         Username
         <input
@@ -53,8 +58,14 @@ export default function ProfileForm({ username }: { username: string }) {
         </label>
       </div>
       {state.error && <p className="text-sm text-rose-300">{state.error}</p>}
-      {state.success && <p className="text-sm text-emerald-300">{state.success}</p>}
-      <button className="admin-primary-button justify-self-start" disabled={pending}>
+      {state.success && (
+        <p className="text-sm text-emerald-300">{state.success}</p>
+      )}
+      <button
+        type="submit"
+        className="admin-primary-button justify-self-start"
+        disabled={pending}
+      >
         {pending ? "Saving…" : "Save profile"}
       </button>
     </form>

--- a/src/app/admin/profile/actions.ts
+++ b/src/app/admin/profile/actions.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import authService, { AuthenticationError } from "@/services/auth-service";
+import { z } from "zod";
+
+export type ProfileState = { error?: string; success?: string };
+
+const profileSchema = z
+  .object({
+    username: z
+      .string()
+      .trim()
+      .min(3, "Username must have at least 3 characters.")
+      .max(80)
+      .regex(/^[a-zA-Z0-9._-]+$/, "Use letters, numbers, dots, dashes or underscores."),
+    currentPassword: z.string().min(1, "Enter your current password."),
+    newPassword: z.string().max(200),
+    confirmPassword: z.string().max(200),
+  })
+  .superRefine((data, context) => {
+    if (data.newPassword && data.newPassword.length < 12) {
+      context.addIssue({
+        code: "custom",
+        path: ["newPassword"],
+        message: "A new password must have at least 12 characters.",
+      });
+    }
+    if (data.newPassword !== data.confirmPassword) {
+      context.addIssue({
+        code: "custom",
+        path: ["confirmPassword"],
+        message: "The new passwords do not match.",
+      });
+    }
+  });
+
+export const updateProfileAction = async (
+  _previousState: ProfileState,
+  formData: FormData,
+): Promise<ProfileState> => {
+  const parsed = profileSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? "Check the form." };
+  }
+
+  try {
+    await authService.updateProfile({
+      username: parsed.data.username,
+      currentPassword: parsed.data.currentPassword,
+      newPassword: parsed.data.newPassword || undefined,
+    });
+    return { success: "Profile updated. Other signed-in sessions are now invalid." };
+  } catch (error) {
+    if (error instanceof AuthenticationError) return { error: error.message };
+    if (
+      error instanceof Error &&
+      error.message.toLowerCase().includes("unique constraint")
+    ) {
+      return { error: "That username is already in use." };
+    }
+    return { error: "The profile could not be updated." };
+  }
+};

--- a/src/app/admin/profile/page.tsx
+++ b/src/app/admin/profile/page.tsx
@@ -1,0 +1,24 @@
+import TopNavigator from "@/components/HomeButton";
+import PageContainer from "@/components/PageContainer";
+import authService from "@/services/auth-service";
+import { redirect } from "next/navigation";
+import ProfileForm from "./ProfileForm";
+
+export default async function ProfilePage() {
+  const user = await authService.getAuthenticatedUser();
+  if (!user) redirect("/admin/login");
+
+  return (
+    <main className="admin-shell min-h-screen">
+      <PageContainer className="mx-auto max-w-3xl">
+        <TopNavigator />
+        <p className="admin-eyebrow mt-10">Account security</p>
+        <h1 className="mt-2 text-3xl font-semibold">Admin profile</h1>
+        <p className="mt-3 text-sm text-slate-400">
+          Changing your password invalidates previous sessions.
+        </p>
+        <ProfileForm username={user.username} />
+      </PageContainer>
+    </main>
+  );
+}

--- a/src/app/admin/rent-rooms/[id]/actions.ts
+++ b/src/app/admin/rent-rooms/[id]/actions.ts
@@ -1,8 +1,10 @@
 "use server";
 import cs from "@/services/cs-scrapping-service";
 import roomsRepo from "@/repositories/renting-rooms-repository";
+import authService from "@/services/auth-service";
 
 export const fetchData = async (formData: FormData) => {
+  await authService.requireAuthenticatedUser();
   const url = formData.get("roomLink");
   if (typeof url !== "string") throw new Error("roomLink is not a string");
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,6 +37,163 @@ body::-webkit-scrollbar-thumb {
   border-radius: 999px;
 }
 
+@theme {
+  --color-admin-page: #07110d;
+  --color-admin-surface: #0d1b16;
+  --color-admin-accent: #6ee7b7;
+}
+
+.admin-shell {
+  color: #eef8f3;
+  background:
+    radial-gradient(circle at 90% -10%, rgba(52, 211, 153, 0.14), transparent 34rem),
+    linear-gradient(rgba(255, 255, 255, 0.015) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.015) 1px, transparent 1px),
+    #07110d;
+  background-size: auto, 64px 64px, 64px 64px, auto;
+}
+
+.admin-panel {
+  background: rgba(13, 27, 22, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.13);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.18);
+}
+
+.admin-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.13);
+}
+
+.admin-nav-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.25rem;
+  padding-inline: 0.75rem;
+  color: #a8b9b1;
+  font-size: 0.8rem;
+  font-weight: 650;
+  border-radius: 0.65rem;
+  transition: color 160ms ease, background 160ms ease;
+}
+
+.admin-nav-link:hover {
+  color: #a7f3d0;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.admin-eyebrow {
+  color: #6ee7b7;
+  font-size: 0.7rem;
+  font-weight: 750;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.admin-input {
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.65rem 0.8rem;
+  color: #eef8f3;
+  background: rgba(3, 10, 7, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 0.75rem;
+  outline: none;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.admin-input:focus {
+  border-color: rgba(110, 231, 183, 0.75);
+  box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.1);
+}
+
+.admin-input:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.admin-primary-button,
+.admin-secondary-button,
+.admin-danger-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6rem;
+  padding: 0.6rem 1rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  border-radius: 0.75rem;
+  transition: transform 160ms ease, opacity 160ms ease, background 160ms ease;
+}
+
+.admin-primary-button {
+  color: #052e22;
+  background: #6ee7b7;
+}
+
+.admin-secondary-button {
+  color: #d5e5de;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.admin-danger-button {
+  color: #fecdd3;
+  background: rgba(244, 63, 94, 0.08);
+  border: 1px solid rgba(251, 113, 133, 0.2);
+}
+
+.admin-primary-button:hover,
+.admin-secondary-button:hover,
+.admin-danger-button:hover {
+  transform: translateY(-1px);
+}
+
+.admin-primary-button:disabled,
+.admin-secondary-button:disabled,
+.admin-danger-button:disabled {
+  cursor: wait;
+  opacity: 0.5;
+}
+
+.admin-stat-card {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1.1rem;
+  background: rgba(13, 27, 22, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.13);
+  border-radius: 1rem;
+}
+
+.admin-stat-card span {
+  color: #82958c;
+  font-size: 0.72rem;
+}
+
+.admin-stat-card strong {
+  font-size: 1.1rem;
+}
+
+.admin-chip,
+.admin-badge {
+  display: inline-flex;
+  padding: 0.3rem 0.55rem;
+  color: #a8b9b1;
+  font-size: 0.72rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 999px;
+}
+
+.admin-badge {
+  color: #a7f3d0;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+}
+
 .portfolio-shell {
   position: relative;
   min-height: 100vh;

--- a/src/components/AppCard.tsx
+++ b/src/components/AppCard.tsx
@@ -4,7 +4,7 @@ export default function AppCard(props: React.ComponentProps<typeof Link>) {
   return (
     <Link
       {...props}
-      className="bg-black border-2 border-white rounded p-1 w-32 h-32 flex items-center justify-center text-center md:text-lg font-semibold hover:bg-white hover:text-black transition-all duration-1000 odd:justify-self-end"
+      className="admin-panel flex min-h-32 items-center justify-center rounded-2xl border border-white/10 p-5 text-center font-semibold transition hover:-translate-y-1 hover:border-emerald-300/40 hover:text-emerald-300"
     />
   );
 }

--- a/src/components/FloatingAction.tsx
+++ b/src/components/FloatingAction.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
 
-const FloatingAction: typeof Link = (props) => {
+export default function FloatingAction(
+  props: React.ComponentProps<typeof Link>,
+) {
   return (
     <Link
-      className="inline-block text-center p-2 border border-gray-300 w-12 h-12 rounded-full text-2xl absolute bottom-8 right-8"
       {...props}
+      className="fixed bottom-6 right-6 z-20 inline-grid h-14 w-14 place-items-center rounded-full bg-emerald-300 text-2xl font-medium text-slate-950 shadow-xl shadow-emerald-950/40 transition hover:scale-105"
     />
   );
-};
-
-export default FloatingAction;
+}

--- a/src/components/HomeButton.tsx
+++ b/src/components/HomeButton.tsx
@@ -1,67 +1,45 @@
-import { Route } from "next";
-import Image, { StaticImageData } from "next/image";
 import Link from "next/link";
-import homeImg from "../../public/home.png";
+import { logoutAction } from "@/app/admin/actions";
+import { Route } from "next";
 
 type NavigationLink = "home" | "money";
 
-type LinkProps = (
-  | {
-      type: "image";
-      src: StaticImageData;
-      alt: string;
-    }
-  | {
-      type: "text";
-      content: string;
-    }
-) & {
-  href: Route;
-};
-
-const links: Record<NavigationLink, LinkProps> = {
-  home: {
-    type: "image",
-    src: homeImg,
-    alt: "home",
-    href: "/admin",
-  },
-  money: {
-    type: "text",
-    content: "M",
-    href: "/admin/money",
-  },
-};
-
-type LinkButtonProps = {
-  linkName: NavigationLink;
-};
-
-const NavigationButton = (props: LinkButtonProps) => {
-  const link = links[props.linkName];
-  return (
-    <Link href={link.href} className="p-1.5">
-      {link.type === "text" ? (
-        <span className="font-bold h-5 w-5 flex items-center justify-center">
-          {link.content}
-        </span>
-      ) : (
-        <Image src={link.src} alt={link.alt} className="max-w-5 max-h-5" />
-      )}
-    </Link>
-  );
+const links: Record<NavigationLink, { href: Route; label: string }> = {
+  home: { href: "/admin", label: "Apps" },
+  money: { href: "/admin/money", label: "Money" },
 };
 
 type TopNavigatorProps = {
-  links: NavigationLink[];
+  links?: NavigationLink[];
 };
 
-export default function TopNavigator(props: Readonly<TopNavigatorProps>) {
+export default function TopNavigator({
+  links: visibleLinks = ["home"],
+}: Readonly<TopNavigatorProps>) {
   return (
-    <div className="flex absolute top-0 left-0 rounded-br-md border-r border-b">
-      {props.links.map((linkName) => (
-        <NavigationButton key={linkName} linkName={linkName} />
-      ))}
-    </div>
+    <nav className="admin-nav" aria-label="Admin navigation">
+      <div className="flex items-center gap-1">
+        {visibleLinks.map((linkName) => (
+          <Link
+            key={linkName}
+            href={links[linkName].href}
+            className="admin-nav-link"
+          >
+            {links[linkName].label}
+          </Link>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-1">
+        <Link href="/admin/profile" className="admin-nav-link">
+          Profile
+        </Link>
+        <form action={logoutAction}>
+          <button className="admin-nav-link cursor-pointer" type="submit">
+            Sign out
+          </button>
+        </form>
+      </div>
+    </nav>
   );
 }

--- a/src/components/PageContainer.tsx
+++ b/src/components/PageContainer.tsx
@@ -2,5 +2,6 @@
  * The main container of the page
  */
 export default function PageContainer(props: React.ComponentProps<"div">) {
-  return <div {...props} className={`py-4 px-6 ${props.className}`} />;
+  const { className = "", ...rest } = props;
+  return <div {...rest} className={`px-5 py-5 sm:px-6 ${className}`} />;
 }

--- a/src/constants/cookies.constants.ts
+++ b/src/constants/cookies.constants.ts
@@ -1,1 +1,10 @@
 export const COOKIE_NAME_REDIRECTED_FROM = "redirected-from";
+export const COOKIE_NAME_ADMIN_SESSION = "admin-session";
+
+export const sessionCookieOptions = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "strict" as const,
+  path: "/",
+  maxAge: 60 * 60 * 24 * 7,
+};

--- a/src/features/money/money.ts
+++ b/src/features/money/money.ts
@@ -1,0 +1,25 @@
+export type MoneyDirection = "IN" | "OUT";
+
+export const formatMoney = (cents: number) =>
+  new Intl.NumberFormat("en-SG", {
+    style: "currency",
+    currency: "SGD",
+    minimumFractionDigits: 2,
+  }).format(cents / 100);
+
+export const parseMoneyToCents = (value: string, allowNegative = false) => {
+  const cleaned = value.trim().replace(/,/g, "");
+  const pattern = allowNegative ? /^-?\d+(\.\d{1,2})?$/ : /^\d+(\.\d{1,2})?$/;
+  if (!pattern.test(cleaned)) {
+    throw new Error("Use a valid SGD amount with no more than two decimals.");
+  }
+  const cents = Math.round(Number(cleaned) * 100);
+  if (!Number.isSafeInteger(cents)) throw new Error("The amount is too large.");
+  return cents;
+};
+
+export const applyTransaction = (
+  balanceCents: number,
+  amountCents: number,
+  direction: MoneyDirection,
+) => balanceCents + (direction === "IN" ? amountCents : -amountCents);

--- a/src/features/money/money.ts
+++ b/src/features/money/money.ts
@@ -8,7 +8,7 @@ export const formatMoney = (cents: number) =>
   }).format(cents / 100);
 
 export const parseMoneyToCents = (value: string, allowNegative = false) => {
-  const cleaned = value.trim().replace(/,/g, "");
+  const cleaned = value.trim().replaceAll(",", "");
   const pattern = allowNegative ? /^-?\d+(\.\d{1,2})?$/ : /^\d+(\.\d{1,2})?$/;
   if (!pattern.test(cleaned)) {
     throw new Error("Use a valid SGD amount with no more than two decimals.");

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,31 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
-import authService from "./services/auth-service";
-import { Route } from "next";
-import { cookies } from "next/headers";
-import { COOKIE_NAME_REDIRECTED_FROM } from "./constants/cookies.constants";
+import {
+  COOKIE_NAME_ADMIN_SESSION,
+  COOKIE_NAME_REDIRECTED_FROM,
+} from "./constants/cookies.constants";
+import { verifySessionToken } from "./services/session-service";
 
-const publicPaths = new Set<Route>(["/", "/my-story", "/admin/login"]);
+const LOGIN_PATH = "/admin/login";
 
-const adminPathsStartWith: Route = "/admin";
+export default async function proxy(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+  if (!pathname.startsWith("/admin")) return NextResponse.next();
 
-export default async function proxy(req: NextRequest) {
-  const { pathname } = req.nextUrl;
+  const session = await verifySessionToken(
+    request.cookies.get(COOKIE_NAME_ADMIN_SESSION)?.value,
+  );
 
-  const isPublicPath = publicPaths.has(pathname as Route);
-  const isAdminPath = pathname.startsWith(adminPathsStartWith);
-
-  if (isPublicPath || isAdminPath) {
-    const isLoggedIn = await authService.isLoggedIn();
-
-    if (isPublicPath && isLoggedIn) {
-      return NextResponse.redirect(new URL("/admin", req.url));
-    } else if (isAdminPath && !isLoggedIn) {
-      const c = await cookies();
-      c.set(COOKIE_NAME_REDIRECTED_FROM, pathname, {
-        httpOnly: true,
-        secure: true,
-      });
-      return NextResponse.rewrite(new URL("/admin/login", req.url));
-    }
+  if (pathname === LOGIN_PATH) {
+    return session
+      ? NextResponse.redirect(new URL("/admin", request.url))
+      : NextResponse.next();
   }
+
+  if (session) return NextResponse.next();
+
+  const response = NextResponse.redirect(new URL(LOGIN_PATH, request.url));
+  response.cookies.set(COOKIE_NAME_REDIRECTED_FROM, `${pathname}${search}`, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict",
+    path: "/admin",
+    maxAge: 60 * 10,
+  });
+  return response;
 }
+
+export const config = {
+  matcher: ["/admin/:path*"],
+};

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -59,7 +59,7 @@ class AuthService {
     const user = await prisma.adminUser.findUnique({
       where: { id: session.userId },
     });
-    if (!user || user.sessionVersion !== session.version) return null;
+    if (user?.sessionVersion !== session.version) return null;
     return user;
   }
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,35 +1,146 @@
+import "server-only";
+
+import { compare, hash } from "bcryptjs";
 import { cookies } from "next/headers";
+import prisma from "./prisma-service";
+import {
+  COOKIE_NAME_ADMIN_SESSION,
+  sessionCookieOptions,
+} from "@/constants/cookies.constants";
+import {
+  AdminSession,
+  createSessionToken,
+  verifySessionToken,
+} from "./session-service";
+
+const PASSWORD_ROUNDS = 12;
+const DUMMY_PASSWORD_HASH =
+  "$2b$12$YqzmPVhiQ68WJzefkwb2qutV6C4xU2ttHgzY45iZPmnICybZwl9zS";
+
+export class AuthenticationError extends Error {
+  constructor(message = "Your session has expired. Please sign in again.") {
+    super(message);
+    this.name = "AuthenticationError";
+  }
+}
 
 class AuthService {
-  private readonly COOKIE_NAME = "admin-auth";
-  private readonly LOGGED_IN_VALUE = "true";
+  async login(usernameInput: string, password: string): Promise<boolean> {
+    const username = usernameInput.trim();
+    let user = await prisma.adminUser.findUnique({ where: { username } });
 
-  async login(username: string, password: string): Promise<boolean> {
-    if (username === "admin" && password === "admin") {
-      const c = await cookies();
-      const sevenDaysInSeconds = 60 * 60 * 24 * 7;
-      c.set(this.COOKIE_NAME, this.LOGGED_IN_VALUE, {
-        httpOnly: true,
-        secure: true,
-        maxAge: sevenDaysInSeconds,
-      });
-      return true;
+    if (!user && (await prisma.adminUser.count()) === 0) {
+      user = await this.bootstrapFirstAdmin(username, password);
     }
 
-    return false;
+    const passwordMatches = await compare(
+      password,
+      user?.passwordHash ?? DUMMY_PASSWORD_HASH,
+    );
+    if (!user || !passwordMatches) return false;
+
+    await this.writeSession({
+      userId: user.id,
+      username: user.username,
+      version: user.sessionVersion,
+    });
+    return true;
   }
 
   async logout(): Promise<void> {
-    const c = await cookies();
-    c.delete(this.COOKIE_NAME);
+    const cookieStore = await cookies();
+    cookieStore.delete(COOKIE_NAME_ADMIN_SESSION);
+  }
+
+  async getSession(): Promise<AdminSession | null> {
+    const cookieStore = await cookies();
+    return verifySessionToken(
+      cookieStore.get(COOKIE_NAME_ADMIN_SESSION)?.value,
+    );
+  }
+
+  async getAuthenticatedUser() {
+    const session = await this.getSession();
+    if (!session) return null;
+
+    const user = await prisma.adminUser.findUnique({
+      where: { id: session.userId },
+    });
+    if (!user || user.sessionVersion !== session.version) return null;
+    return user;
+  }
+
+  async requireAuthenticatedUser() {
+    const user = await this.getAuthenticatedUser();
+    if (!user) throw new AuthenticationError();
+    return user;
   }
 
   async isLoggedIn(): Promise<boolean> {
-    const c = await cookies();
-    return c.get(this.COOKIE_NAME)?.value === this.LOGGED_IN_VALUE;
+    return (await this.getAuthenticatedUser()) !== null;
+  }
+
+  async updateProfile(input: {
+    username: string;
+    currentPassword: string;
+    newPassword?: string;
+  }) {
+    const user = await this.requireAuthenticatedUser();
+    if (!(await compare(input.currentPassword, user.passwordHash))) {
+      throw new AuthenticationError("The current password is incorrect.");
+    }
+
+    const username = input.username.trim();
+    const passwordHash = input.newPassword
+      ? await hash(input.newPassword, PASSWORD_ROUNDS)
+      : user.passwordHash;
+
+    const updated = await prisma.adminUser.update({
+      where: { id: user.id },
+      data: {
+        username,
+        passwordHash,
+        sessionVersion: { increment: 1 },
+      },
+    });
+
+    await this.writeSession({
+      userId: updated.id,
+      username: updated.username,
+      version: updated.sessionVersion,
+    });
+    return updated;
+  }
+
+  private async writeSession(session: AdminSession) {
+    const cookieStore = await cookies();
+    cookieStore.set(
+      COOKIE_NAME_ADMIN_SESSION,
+      await createSessionToken(session),
+      sessionCookieOptions,
+    );
+  }
+
+  private async bootstrapFirstAdmin(username: string, password: string) {
+    const bootstrapUsername = process.env.ADMIN_BOOTSTRAP_USERNAME;
+    const bootstrapPassword = process.env.ADMIN_BOOTSTRAP_PASSWORD;
+    if (
+      !bootstrapUsername ||
+      !bootstrapPassword ||
+      username !== bootstrapUsername ||
+      password !== bootstrapPassword
+    ) {
+      return null;
+    }
+
+    return prisma.adminUser.create({
+      data: {
+        username,
+        passwordHash: await hash(password, PASSWORD_ROUNDS),
+      },
+    });
   }
 }
 
 const authService = new AuthService();
-
 export default authService;

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -14,8 +14,6 @@ import {
 } from "./session-service";
 
 const PASSWORD_ROUNDS = 12;
-const DUMMY_PASSWORD_HASH =
-  "$2b$12$YqzmPVhiQ68WJzefkwb2qutV6C4xU2ttHgzY45iZPmnICybZwl9zS";
 
 export class AuthenticationError extends Error {
   constructor(message = "Your session has expired. Please sign in again.") {
@@ -27,17 +25,12 @@ export class AuthenticationError extends Error {
 class AuthService {
   async login(usernameInput: string, password: string): Promise<boolean> {
     const username = usernameInput.trim();
-    let user = await prisma.adminUser.findUnique({ where: { username } });
+    const user = await prisma.adminUser.findUnique({ where: { username } });
 
-    if (!user && (await prisma.adminUser.count()) === 0) {
-      user = await this.bootstrapFirstAdmin(username, password);
-    }
+    if (!user) return false;
 
-    const passwordMatches = await compare(
-      password,
-      user?.passwordHash ?? DUMMY_PASSWORD_HASH,
-    );
-    if (!user || !passwordMatches) return false;
+    const passwordMatches = await compare(password, user.passwordHash);
+    if (!passwordMatches) return false;
 
     await this.writeSession({
       userId: user.id,

--- a/src/services/categories.service.ts
+++ b/src/services/categories.service.ts
@@ -37,6 +37,7 @@ export class CategoriesService {
         name: UNCLASSIFIED_CATEGORY_NAME,
         normalizedName,
         isSystem: true,
+        parentId: null,
       },
     });
   }
@@ -69,7 +70,8 @@ export class CategoriesService {
       },
     });
     return (
-      existing ?? prisma.category.create({ data: { name, normalizedName } })
+      existing ??
+      prisma.category.create({ data: { name, normalizedName, parentId: null } })
     );
   }
 
@@ -166,3 +168,8 @@ export class CategoriesService {
 
 const categoriesService = new CategoriesService();
 export default categoriesService;
+
+/**
+ * NOTES:
+ * When creating categories don't leave parentId to undefined. This is to keep the DB consistent
+ */

--- a/src/services/categories.service.ts
+++ b/src/services/categories.service.ts
@@ -33,7 +33,11 @@ export class CategoriesService {
       });
     }
     return prisma.category.create({
-      data: { name: UNCLASSIFIED_CATEGORY_NAME, normalizedName, isSystem: true },
+      data: {
+        name: UNCLASSIFIED_CATEGORY_NAME,
+        normalizedName,
+        isSystem: true,
+      },
     });
   }
 
@@ -64,18 +68,23 @@ export class CategoriesService {
         ],
       },
     });
-    return existing ?? prisma.category.create({ data: { name, normalizedName } });
+    return (
+      existing ?? prisma.category.create({ data: { name, normalizedName } })
+    );
   }
 
   async updateCategory(id: string, dto: UpdateCategoryDto) {
     const existing = await this.getCategoryById(id);
     if (!existing) throw new Error("Category not found.");
-    if (existing.isSystem) throw new Error("The Unclassified category cannot be edited.");
-    if (dto.parentId === id) throw new Error("A category cannot be its own parent.");
+    if (existing.isSystem)
+      throw new Error("The Unclassified category cannot be edited.");
+    if (dto.parentId === id)
+      throw new Error("A category cannot be its own parent.");
     if (dto.parentId) await this.validateParent(dto.parentId);
 
     const name = dto.name === undefined ? undefined : cleanName(dto.name);
-    if (name !== undefined && !name) throw new Error("Category name is required.");
+    if (name !== undefined && !name)
+      throw new Error("Category name is required.");
 
     return prisma.category.update({
       where: { id },
@@ -90,7 +99,8 @@ export class CategoriesService {
   async deleteCategory(id: string) {
     const category = await this.getCategoryById(id);
     if (!category) return;
-    if (category.isSystem) throw new Error("The Unclassified category cannot be deleted.");
+    if (category.isSystem)
+      throw new Error("The Unclassified category cannot be deleted.");
 
     const unclassified = await this.ensureUnclassified();
     await prisma.transaction.updateMany({
@@ -147,8 +157,10 @@ export class CategoriesService {
   private async validateParent(parentId: string) {
     const parent = await this.getCategoryById(parentId);
     if (!parent) throw new Error("Parent category not found.");
-    if (parent.isSystem) throw new Error("Unclassified cannot have subcategories.");
-    if (parent.parentId) throw new Error("Subcategories cannot have subcategories.");
+    if (parent.isSystem)
+      throw new Error("Unclassified cannot have subcategories.");
+    if (parent.parentId)
+      throw new Error("Subcategories cannot have subcategories.");
   }
 }
 

--- a/src/services/categories.service.ts
+++ b/src/services/categories.service.ts
@@ -1,90 +1,154 @@
-import { Category } from "@/generated/prisma/client";
+import "server-only";
+
 import prisma from "./prisma-service";
 
-export type CreateCategoryDto = Pick<Category, "name" | "parentId">;
+export const UNCLASSIFIED_CATEGORY_NAME = "Unclassified";
 
+export type CreateCategoryDto = {
+  name: string;
+  parentId: string | null;
+};
 export type UpdateCategoryDto = Partial<CreateCategoryDto>;
 
-export class CategoriesService {
-  async createCategory(dto: CreateCategoryDto) {
-    const c = await prisma.category.create({
-      data: dto,
-    });
+const normalizeName = (name: string) =>
+  name.trim().replace(/\s+/g, " ").toLocaleLowerCase("en-US");
 
-    return c;
+const cleanName = (name: string) => name.trim().replace(/\s+/g, " ");
+
+export class CategoriesService {
+  async ensureUnclassified() {
+    const normalizedName = normalizeName(UNCLASSIFIED_CATEGORY_NAME);
+    const existing = await prisma.category.findFirst({
+      where: {
+        OR: [
+          { normalizedName },
+          { name: { equals: UNCLASSIFIED_CATEGORY_NAME, mode: "insensitive" } },
+        ],
+      },
+    });
+    if (existing) {
+      return prisma.category.update({
+        where: { id: existing.id },
+        data: { normalizedName, isSystem: true, parentId: null },
+      });
+    }
+    return prisma.category.create({
+      data: { name: UNCLASSIFIED_CATEGORY_NAME, normalizedName, isSystem: true },
+    });
+  }
+
+  async createCategory(dto: CreateCategoryDto) {
+    const name = cleanName(dto.name);
+    if (!name) throw new Error("Category name is required.");
+    if (dto.parentId) await this.validateParent(dto.parentId);
+
+    return prisma.category.create({
+      data: {
+        name,
+        normalizedName: normalizeName(name),
+        parentId: dto.parentId,
+      },
+    });
+  }
+
+  async findOrCreateByName(nameInput?: string | null) {
+    const name = cleanName(nameInput ?? "");
+    if (!name) return this.ensureUnclassified();
+
+    const normalizedName = normalizeName(name);
+    const existing = await prisma.category.findFirst({
+      where: {
+        OR: [
+          { normalizedName },
+          { name: { equals: name, mode: "insensitive" } },
+        ],
+      },
+    });
+    return existing ?? prisma.category.create({ data: { name, normalizedName } });
   }
 
   async updateCategory(id: string, dto: UpdateCategoryDto) {
-    if (dto.parentId) await this.validateParentCategory(id, dto.parentId);
+    const existing = await this.getCategoryById(id);
+    if (!existing) throw new Error("Category not found.");
+    if (existing.isSystem) throw new Error("The Unclassified category cannot be edited.");
+    if (dto.parentId === id) throw new Error("A category cannot be its own parent.");
+    if (dto.parentId) await this.validateParent(dto.parentId);
 
-    const c = await prisma.category.update({
+    const name = dto.name === undefined ? undefined : cleanName(dto.name);
+    if (name !== undefined && !name) throw new Error("Category name is required.");
+
+    return prisma.category.update({
       where: { id },
-      data: dto,
+      data: {
+        name,
+        normalizedName: name ? normalizeName(name) : undefined,
+        parentId: dto.parentId,
+      },
     });
-    return c;
   }
 
   async deleteCategory(id: string) {
-    await prisma.category.delete({
-      where: { id },
+    const category = await this.getCategoryById(id);
+    if (!category) return;
+    if (category.isSystem) throw new Error("The Unclassified category cannot be deleted.");
+
+    const unclassified = await this.ensureUnclassified();
+    await prisma.transaction.updateMany({
+      where: { categoryId: id },
+      data: { categoryId: unclassified.id },
     });
+    await prisma.category.updateMany({
+      where: { parentId: id },
+      data: { parentId: null },
+    });
+    await prisma.category.delete({ where: { id } });
   }
 
   async getCategoryById(id: string) {
-    const c = await prisma.category.findUnique({
-      where: { id },
-    });
-    return c;
+    return prisma.category.findUnique({ where: { id } });
   }
 
   async getAllCategories() {
-    const categories = await prisma.category.findMany();
-    return categories;
+    await this.ensureUnclassified();
+    return prisma.category.findMany({
+      orderBy: [{ isSystem: "desc" }, { name: "asc" }],
+    });
   }
 
-  async getNonChildCategories(id: string) {
-    const categories = await this.getAllCategories();
-    const childCategoryIds = new Set<string>();
-    const queue: string[] = [id];
-    while (queue.length > 0) {
-      const currentId = queue.shift()!;
-      for (const category of categories) {
-        if (category.parentId === currentId) {
-          childCategoryIds.add(category.id);
-          queue.push(category.id);
-        }
-      }
-    }
-    return categories.filter((category) => !childCategoryIds.has(category.id));
+  async getAvailableParents(currentId?: string) {
+    return prisma.category.findMany({
+      where: {
+        id: currentId ? { not: currentId } : undefined,
+        parentId: null,
+        isSystem: false,
+      },
+      orderBy: { name: "asc" },
+    });
   }
 
   async hasChildCategories(id: string) {
-    const count = await prisma.category.count({
-      where: { parentId: id },
-    });
-    return count > 0;
+    return (await prisma.category.count({ where: { parentId: id } })) > 0;
   }
 
-  async nameExists(name: string) {
-    const count = await prisma.category.count({
-      where: { name },
-    });
-    return count > 0;
+  async nameExists(name: string, exceptId?: string) {
+    return (
+      (await prisma.category.count({
+        where: {
+          OR: [
+            { normalizedName: normalizeName(name) },
+            { name: { equals: cleanName(name), mode: "insensitive" } },
+          ],
+          id: exceptId ? { not: exceptId } : undefined,
+        },
+      })) > 0
+    );
   }
 
-  /**
-   * Validates that the parent category does not create a circular reference.
-   */
-  private async validateParentCategory(categoryId: string, parentId: string) {
-    let currentParentId = parentId;
-    while (currentParentId) {
-      if (currentParentId === categoryId) {
-        throw new Error("A category cannot be its own parent.");
-      }
-      const parentCategory = await this.getCategoryById(currentParentId);
-      if (!parentCategory) break;
-      currentParentId = parentCategory.parentId!;
-    }
+  private async validateParent(parentId: string) {
+    const parent = await this.getCategoryById(parentId);
+    if (!parent) throw new Error("Parent category not found.");
+    if (parent.isSystem) throw new Error("Unclassified cannot have subcategories.");
+    if (parent.parentId) throw new Error("Subcategories cannot have subcategories.");
   }
 }
 

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -1,0 +1,61 @@
+import { SignJWT, jwtVerify } from "jose";
+
+const ISSUER = "lasindu-portfolio";
+const AUDIENCE = "portfolio-admin";
+
+export type AdminSession = {
+  userId: string;
+  username: string;
+  version: number;
+};
+
+const getSecret = () => {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error("AUTH_SECRET must contain at least 32 characters.");
+  }
+  return new TextEncoder().encode(secret);
+};
+
+export const createSessionToken = async (session: AdminSession) =>
+  new SignJWT({
+    username: session.username,
+    version: session.version,
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(session.userId)
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime("7d")
+    .sign(getSecret());
+
+export const verifySessionToken = async (
+  token: string | undefined,
+): Promise<AdminSession | null> => {
+  if (!token) return null;
+
+  try {
+    const { payload } = await jwtVerify(token, getSecret(), {
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      algorithms: ["HS256"],
+    });
+
+    if (
+      !payload.sub ||
+      typeof payload.username !== "string" ||
+      typeof payload.version !== "number"
+    ) {
+      return null;
+    }
+
+    return {
+      userId: payload.sub,
+      username: payload.username,
+      version: payload.version,
+    };
+  } catch {
+    return null;
+  }
+};

--- a/src/services/transactions.service.ts
+++ b/src/services/transactions.service.ts
@@ -1,43 +1,212 @@
-import { Transaction } from "@/generated/prisma/client";
-import prisma from "./prisma-service";
+import "server-only";
 
-export type CreateTransactionDto = Omit<Transaction, "id">;
-export type UpdateTransactionDto = Partial<CreateTransactionDto>;
+import { TransactionDirection } from "@/generated/prisma/client";
+import prisma from "./prisma-service";
+import categoriesService from "./categories.service";
+
+const PRIMARY_ACCOUNT_ID = "primary";
+
+export type SaveTransactionDto = {
+  amountCents: number;
+  direction: TransactionDirection;
+  title: string;
+  comments: string | null;
+  time: Date;
+  categoryId?: string | null;
+  categoryName?: string | null;
+};
+
+export type TransactionFilters = {
+  categoryId?: string;
+  direction?: TransactionDirection;
+  from?: Date;
+  to?: Date;
+  search?: string;
+};
 
 export class TransactionsService {
-  async create(dto: CreateTransactionDto) {
-    const t = await prisma.transaction.create({
-      data: dto,
+  async create(dto: SaveTransactionDto) {
+    this.validate(dto);
+    const categoryId = await this.resolveCategory(dto);
+    return prisma.transaction.create({
+      data: {
+        amountCents: dto.amountCents,
+        direction: dto.direction,
+        title: dto.title.trim(),
+        comments: dto.comments?.trim() || null,
+        time: dto.time,
+        categoryId,
+      },
     });
-    return t;
   }
 
-  async update(id: string, dto: UpdateTransactionDto) {
-    const t = await prisma.transaction.update({
+  async update(id: string, dto: SaveTransactionDto) {
+    this.validate(dto);
+    const categoryId = await this.resolveCategory(dto);
+    return prisma.transaction.update({
       where: { id },
-      data: dto,
+      data: {
+        amountCents: dto.amountCents,
+        direction: dto.direction,
+        title: dto.title.trim(),
+        comments: dto.comments?.trim() || null,
+        time: dto.time,
+        categoryId,
+      },
     });
-    return t;
   }
 
   async delete(id: string) {
-    await prisma.transaction.delete({
-      where: { id },
-    });
+    await prisma.transaction.delete({ where: { id } });
   }
 
   async getById(id: string) {
-    const t = await prisma.transaction.findUnique({
+    const transaction = await prisma.transaction.findUnique({
       where: { id },
+      include: { category: true },
     });
-    return t;
+    return transaction ? this.normalizeLegacyTransaction(transaction) : null;
   }
 
-  async getAll() {
+  async getAll(filters: TransactionFilters = {}) {
     const transactions = await prisma.transaction.findMany({
-      orderBy: { time: "desc" },
+      where: this.buildWhere(filters),
+      include: { category: true },
+      orderBy: [{ time: "desc" }, { createdAt: "desc" }],
     });
-    return transactions;
+    return Promise.all(
+      transactions.map((transaction) => this.normalizeLegacyTransaction(transaction)),
+    );
+  }
+
+  async getOpeningBalanceCents() {
+    const account = await prisma.moneyAccount.upsert({
+      where: { id: PRIMARY_ACCOUNT_ID },
+      create: { id: PRIMARY_ACCOUNT_ID },
+      update: {},
+    });
+    return account.openingBalanceCents;
+  }
+
+  async setOpeningBalanceCents(openingBalanceCents: number) {
+    if (!Number.isSafeInteger(openingBalanceCents)) {
+      throw new Error("Opening balance is invalid.");
+    }
+    return prisma.moneyAccount.upsert({
+      where: { id: PRIMARY_ACCOUNT_ID },
+      create: { id: PRIMARY_ACCOUNT_ID, openingBalanceCents },
+      update: { openingBalanceCents },
+    });
+  }
+
+  async getBalanceCents(excludingTransactionId?: string) {
+    await this.migrateLegacyTransactions();
+    const [openingBalanceCents, incoming, outgoing] = await Promise.all([
+      this.getOpeningBalanceCents(),
+      prisma.transaction.aggregate({
+        where: {
+          direction: "IN",
+          id: excludingTransactionId ? { not: excludingTransactionId } : undefined,
+        },
+        _sum: { amountCents: true },
+      }),
+      prisma.transaction.aggregate({
+        where: {
+          direction: "OUT",
+          id: excludingTransactionId ? { not: excludingTransactionId } : undefined,
+        },
+        _sum: { amountCents: true },
+      }),
+    ]);
+
+    return (
+      openingBalanceCents +
+      (incoming._sum.amountCents ?? 0) -
+      (outgoing._sum.amountCents ?? 0)
+    );
+  }
+
+  private async resolveCategory(dto: SaveTransactionDto) {
+    if (dto.categoryId) {
+      const category = await categoriesService.getCategoryById(dto.categoryId);
+      if (category) return category.id;
+    }
+    return (await categoriesService.findOrCreateByName(dto.categoryName)).id;
+  }
+
+  private validate(dto: SaveTransactionDto) {
+    if (!Number.isSafeInteger(dto.amountCents) || dto.amountCents <= 0) {
+      throw new Error("Amount must be greater than zero and have at most two decimals.");
+    }
+    if (!dto.title.trim()) throw new Error("Title is required.");
+    if (Number.isNaN(dto.time.getTime())) throw new Error("Date is invalid.");
+  }
+
+  private async migrateLegacyTransactions() {
+    const transactions = await prisma.transaction.findMany({
+      include: { category: true },
+    });
+    await Promise.all(
+      transactions
+        .filter(
+          (transaction) =>
+            transaction.amountCents === null ||
+            transaction.direction === null ||
+            transaction.category === null,
+        )
+        .map((transaction) => this.normalizeLegacyTransaction(transaction)),
+    );
+  }
+
+  private async normalizeLegacyTransaction(
+    transaction: Awaited<
+      ReturnType<typeof prisma.transaction.findMany<{ include: { category: true } }>>
+    >[number],
+  ) {
+    if (
+      transaction.amountCents !== null &&
+      transaction.direction !== null &&
+      transaction.category !== null
+    ) {
+      return {
+        ...transaction,
+        amountCents: transaction.amountCents,
+        direction: transaction.direction,
+        category: transaction.category,
+      };
+    }
+
+    const category = transaction.category ?? (await categoriesService.ensureUnclassified());
+    const legacyAmount = transaction.amount ?? 0;
+    return prisma.transaction.update({
+      where: { id: transaction.id },
+      data: {
+        amountCents: transaction.amountCents ?? Math.abs(Math.round(legacyAmount * 100)),
+        direction: transaction.direction ?? "OUT",
+        categoryId: category.id,
+      },
+      include: { category: true },
+    }) as Promise<
+      typeof transaction & {
+        amountCents: number;
+        direction: TransactionDirection;
+        category: NonNullable<typeof transaction.category>;
+      }
+    >;
+  }
+
+  private buildWhere(filters: TransactionFilters) {
+    return {
+      categoryId: filters.categoryId || undefined,
+      direction: filters.direction,
+      time:
+        filters.from || filters.to
+          ? { gte: filters.from, lte: filters.to }
+          : undefined,
+      title: filters.search
+        ? { contains: filters.search.trim(), mode: "insensitive" as const }
+        : undefined,
+    };
   }
 }
 

--- a/src/services/transactions.service.ts
+++ b/src/services/transactions.service.ts
@@ -86,7 +86,7 @@ export class TransactionsService {
 
   async setOpeningBalanceCents(openingBalanceCents: number) {
     if (!Number.isSafeInteger(openingBalanceCents)) {
-      throw new Error("Opening balance is invalid.");
+      throw new TypeError("Opening balance is invalid.");
     }
     return prisma.moneyAccount.upsert({
       where: { id: PRIMARY_ACCOUNT_ID },
@@ -101,14 +101,18 @@ export class TransactionsService {
       prisma.transaction.aggregate({
         where: {
           direction: "IN",
-          id: excludingTransactionId ? { not: excludingTransactionId } : undefined,
+          id: excludingTransactionId
+            ? { not: excludingTransactionId }
+            : undefined,
         },
         _sum: { amountCents: true },
       }),
       prisma.transaction.aggregate({
         where: {
           direction: "OUT",
-          id: excludingTransactionId ? { not: excludingTransactionId } : undefined,
+          id: excludingTransactionId
+            ? { not: excludingTransactionId }
+            : undefined,
         },
         _sum: { amountCents: true },
       }),
@@ -131,7 +135,9 @@ export class TransactionsService {
 
   private validate(dto: SaveTransactionDto) {
     if (!Number.isSafeInteger(dto.amountCents) || dto.amountCents <= 0) {
-      throw new Error("Amount must be greater than zero and have at most two decimals.");
+      throw new Error(
+        "Amount must be greater than zero and have at most two decimals.",
+      );
     }
     if (!dto.title.trim()) throw new Error("Title is required.");
     if (Number.isNaN(dto.time.getTime())) throw new Error("Date is invalid.");

--- a/src/services/transactions.service.ts
+++ b/src/services/transactions.service.ts
@@ -61,22 +61,18 @@ export class TransactionsService {
   }
 
   async getById(id: string) {
-    const transaction = await prisma.transaction.findUnique({
+    return prisma.transaction.findUnique({
       where: { id },
       include: { category: true },
     });
-    return transaction ? this.normalizeLegacyTransaction(transaction) : null;
   }
 
   async getAll(filters: TransactionFilters = {}) {
-    const transactions = await prisma.transaction.findMany({
+    return prisma.transaction.findMany({
       where: this.buildWhere(filters),
       include: { category: true },
       orderBy: [{ time: "desc" }, { createdAt: "desc" }],
     });
-    return Promise.all(
-      transactions.map((transaction) => this.normalizeLegacyTransaction(transaction)),
-    );
   }
 
   async getOpeningBalanceCents() {
@@ -100,7 +96,6 @@ export class TransactionsService {
   }
 
   async getBalanceCents(excludingTransactionId?: string) {
-    await this.migrateLegacyTransactions();
     const [openingBalanceCents, incoming, outgoing] = await Promise.all([
       this.getOpeningBalanceCents(),
       prisma.transaction.aggregate({
@@ -140,59 +135,6 @@ export class TransactionsService {
     }
     if (!dto.title.trim()) throw new Error("Title is required.");
     if (Number.isNaN(dto.time.getTime())) throw new Error("Date is invalid.");
-  }
-
-  private async migrateLegacyTransactions() {
-    const transactions = await prisma.transaction.findMany({
-      include: { category: true },
-    });
-    await Promise.all(
-      transactions
-        .filter(
-          (transaction) =>
-            transaction.amountCents === null ||
-            transaction.direction === null ||
-            transaction.category === null,
-        )
-        .map((transaction) => this.normalizeLegacyTransaction(transaction)),
-    );
-  }
-
-  private async normalizeLegacyTransaction(
-    transaction: Awaited<
-      ReturnType<typeof prisma.transaction.findMany<{ include: { category: true } }>>
-    >[number],
-  ) {
-    if (
-      transaction.amountCents !== null &&
-      transaction.direction !== null &&
-      transaction.category !== null
-    ) {
-      return {
-        ...transaction,
-        amountCents: transaction.amountCents,
-        direction: transaction.direction,
-        category: transaction.category,
-      };
-    }
-
-    const category = transaction.category ?? (await categoriesService.ensureUnclassified());
-    const legacyAmount = transaction.amount ?? 0;
-    return prisma.transaction.update({
-      where: { id: transaction.id },
-      data: {
-        amountCents: transaction.amountCents ?? Math.abs(Math.round(legacyAmount * 100)),
-        direction: transaction.direction ?? "OUT",
-        categoryId: category.id,
-      },
-      include: { category: true },
-    }) as Promise<
-      typeof transaction & {
-        amountCents: number;
-        direction: TransactionDirection;
-        category: NonNullable<typeof transaction.category>;
-      }
-    >;
   }
 
   private buildWhere(filters: TransactionFilters) {

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const source: string;
+  export default source;
+}


### PR DESCRIPTION
## What changed

- replace the hard-coded boolean admin cookie with database-backed bcrypt credentials and signed sessions
- protect admin routes and mutating actions, add profile/password management, logout, security headers, and private caching
- implement exact-cent SGD balances, opening balance, IN/OUT transactions, category hierarchy, and Unclassified handling
- use a clean, strict money schema for the empty database: amount, direction, and category are required, legacy floating-point fields and read-time migrations are removed, and normalized category names are unique
- add responsive transaction entry/editing, desktop filtering/statistics/charts, and an oldest-first paginated mobile ledger
- document first-deployment bootstrap and production rate-limiting guidance

## Why

The previous hidden money tool used hard-coded credentials and did not provide the category, balance, reporting, or responsive workflows needed for regular use. Historical money data has been intentionally removed, so the new implementation can enforce its invariants directly instead of carrying compatibility code.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts` with pnpm 10.28.1
- `pnpm lint`
- `pnpm build`
- fresh-schema follow-up reviewed for required transaction fields and removal of all legacy transaction paths
