### PR TITLE
Complete the expanded money workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ The private `/admin` area now includes a maintainable SGD ledger with:
 - profile and password management with session invalidation;
 - exact integer-cent money calculations, opening balance, and IN/OUT entries;
 - top-level categories, one level of subcategories, and a protected Unclassified category;
-- category suggestions and automatic creation while entering a transaction;
-- filtered statistics, cash-flow and spending charts, and paginated transactions;
+- transaction instruments with a configurable default and a shared account balance;
+- monthly parent/subcategory budgets with enforced allocation limits;
+- advanced, saveable filters plus budget, cash-flow, and category reporting;
 - a compact oldest-first mobile ledger and an adaptive desktop dashboard.
 
 ### Security notes
@@ -21,7 +22,9 @@ The private `/admin` area now includes a maintainable SGD ledger with:
 - Admin responses are private and non-cacheable. Baseline framing, MIME-sniffing, referrer, and permissions headers are configured in `next.config.ts`.
 - For internet exposure, enable rate limiting for `/admin/login` at the hosting/WAF layer. In-memory counters are not reliable in a serverless deployment.
 
-## Plan
+## Implemented money plan
+
+The following scope has been implemented:
 
 - Improve styling
   - use TailwindCSS theme to name frequently used TailwindCSS classes (eg: primary color, secondary color, page gap)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,32 +37,36 @@ model RentingRoom {
 }
 
 model Category {
-  id             String        @id @default(auto()) @map("_id") @db.ObjectId
-  name           String
-  normalizedName String        @unique
-  isSystem       Boolean       @default(false)
-  parentId       String?       @db.ObjectId
-  parent         Category?     @relation("CategoryHierarchy", fields: [parentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  children       Category[]    @relation("CategoryHierarchy")
-  transactions   Transaction[]
-  createdAt      DateTime      @default(now())
-  updatedAt      DateTime      @updatedAt
+  id                 String        @id @default(auto()) @map("_id") @db.ObjectId
+  name               String
+  normalizedName     String        @unique
+  isSystem           Boolean       @default(false)
+  parentId           String?       @db.ObjectId
+  parent             Category?     @relation("CategoryHierarchy", fields: [parentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  children           Category[]    @relation("CategoryHierarchy")
+  transactions       Transaction[]
+  monthlyBudgetCents Int           @default(0)
+  createdAt          DateTime      @default(now())
+  updatedAt          DateTime      @updatedAt
 }
 
 model Transaction {
-  id          String               @id @default(auto()) @map("_id") @db.ObjectId
-  amountCents Int
-  direction   TransactionDirection
-  title       String
-  time        DateTime             @default(now())
-  comments    String?
-  category    Category             @relation(fields: [categoryId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  categoryId  String               @db.ObjectId
-  createdAt   DateTime             @default(now())
-  updatedAt   DateTime             @updatedAt
+  id           String               @id @default(auto()) @map("_id") @db.ObjectId
+  amountCents  Int
+  direction    TransactionDirection
+  title        String
+  time         DateTime             @default(now())
+  comments     String?
+  category     Category             @relation(fields: [categoryId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  categoryId   String               @db.ObjectId
+  instrument   Instrument           @relation(fields: [instrumentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  instrumentId String               @db.ObjectId
+  createdAt    DateTime             @default(now())
+  updatedAt    DateTime             @updatedAt
 
   @@index([time])
   @@index([categoryId])
+  @@index([instrumentId])
 }
 
 enum TransactionDirection {
@@ -71,17 +75,61 @@ enum TransactionDirection {
 }
 
 model MoneyAccount {
-  id                  String   @id @default("primary") @map("_id")
-  openingBalanceCents Int      @default(0)
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  id                  String      @id @default("primary") @map("_id")
+  openingBalanceCents Int         @default(0)
+  defaultInstrument   Instrument? @relation("DefaultInstrument", fields: [defaultInstrumentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  defaultInstrumentId String?     @db.ObjectId
+  createdAt           DateTime    @default(now())
+  updatedAt           DateTime    @updatedAt
+}
+
+model Instrument {
+  id                 String         @id @default(auto()) @map("_id") @db.ObjectId
+  name               String
+  normalizedName     String         @unique
+  isCreditCard       Boolean        @default(false)
+  transactions       Transaction[]
+  defaultForAccounts MoneyAccount[] @relation("DefaultInstrument")
+  createdAt          DateTime       @default(now())
+  updatedAt          DateTime       @updatedAt
 }
 
 model AdminUser {
-  id             String   @id @default(auto()) @map("_id") @db.ObjectId
-  username       String   @unique
-  passwordHash   String
-  sessionVersion Int      @default(1)
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  id                String             @id @default(auto()) @map("_id") @db.ObjectId
+  username          String             @unique
+  passwordHash      String
+  sessionVersion    Int                @default(1)
+  savedMoneyFilters SavedMoneyFilter[]
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
+}
+
+model SavedMoneyFilter {
+  id                String                @id @default(auto()) @map("_id") @db.ObjectId
+  name              String
+  normalizedName    String
+  direction         TransactionDirection  @default(OUT)
+  categoryIds       String[]              @db.ObjectId
+  showSubcategories Boolean               @default(true)
+  rangePreset       MoneyDateRangePreset?
+  from              DateTime?
+  to                DateTime?
+  showCashflow      Boolean               @default(false)
+  adminUser         AdminUser             @relation(fields: [adminUserId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  adminUserId       String                @db.ObjectId
+  createdAt         DateTime              @default(now())
+  updatedAt         DateTime              @updatedAt
+
+  @@unique([adminUserId, normalizedName])
+  @@index([adminUserId])
+}
+
+enum MoneyDateRangePreset {
+  TODAY
+  THIS_WEEK
+  LAST_WEEK
+  THIS_MONTH
+  LAST_MONTH
+  THIS_YEAR
+  LAST_YEAR
 }

--- a/src/app/admin/money/categories/[id]/actions.ts
+++ b/src/app/admin/money/categories/[id]/actions.ts
@@ -1,10 +1,8 @@
 "use server";
 
 import authService from "@/services/auth-service";
-import categoriesService, {
-  CreateCategoryDto,
-  UpdateCategoryDto,
-} from "@/services/categories.service";
+import { parseMoneyToCents } from "@/features/money/money";
+import categoriesService from "@/services/categories.service";
 import { revalidatePath } from "next/cache";
 
 export const deleteAction = async (id: string) => {
@@ -14,8 +12,21 @@ export const deleteAction = async (id: string) => {
   revalidatePath("/admin/money/transactions");
 };
 
-export const createAction = async (params: CreateCategoryDto) => {
+type CategoryInput = {
+  name: string;
+  parentId: string | null;
+  monthlyBudget: string;
+};
+
+const parse = (params: CategoryInput) => ({
+  name: params.name,
+  parentId: params.parentId,
+  monthlyBudgetCents: parseMoneyToCents(params.monthlyBudget),
+});
+
+export const createAction = async (input: CategoryInput) => {
   await authService.requireAuthenticatedUser();
+  const params = parse(input);
   if (await categoriesService.nameExists(params.name)) {
     throw new Error("A category with that name already exists.");
   }
@@ -24,8 +35,9 @@ export const createAction = async (params: CreateCategoryDto) => {
   return created.id;
 };
 
-export const updateAction = async (id: string, params: UpdateCategoryDto) => {
+export const updateAction = async (id: string, input: CategoryInput) => {
   await authService.requireAuthenticatedUser();
+  const params = parse(input);
   if (params.name && (await categoriesService.nameExists(params.name, id))) {
     throw new Error("A category with that name already exists.");
   }

--- a/src/app/admin/money/categories/[id]/components/ClientForm.tsx
+++ b/src/app/admin/money/categories/[id]/components/ClientForm.tsx
@@ -20,6 +20,7 @@ type Category = {
   name: string;
   parentId: string | null;
   isSystem: boolean;
+  monthlyBudgetCents: number;
 };
 
 type ClientFormProps = {
@@ -28,7 +29,11 @@ type ClientFormProps = {
   categories: Pick<Category, "id" | "name">[];
 };
 
-type FormEntries = { [k in keyof Pick<Category, "name" | "parentId">]: string };
+type FormEntries = {
+  name: string;
+  parentId: string;
+  monthlyBudget: string;
+};
 
 const _onSaveClick = async (form: HTMLFormElement, id?: string) => {
   const formData = new FormData(form);
@@ -36,6 +41,7 @@ const _onSaveClick = async (form: HTMLFormElement, id?: string) => {
   const data = {
     name: entries.name,
     parentId: entries.parentId === "" ? null : entries.parentId,
+    monthlyBudget: entries.monthlyBudget,
   };
 
   if (id) await updateAction(id, data);
@@ -67,6 +73,7 @@ export default function ClientForm(props: Readonly<ClientFormProps>) {
   }, [props.category, props.isNew, router]);
 
   const onDeleteClick = useCallback(async () => {
+    if (!confirm(`Delete ${props.category?.name}?`)) return;
     setPending(true);
     try {
       await deleteAction(props.category!.id);
@@ -80,7 +87,14 @@ export default function ClientForm(props: Readonly<ClientFormProps>) {
   }, [props.category, router]);
 
   return (
-    <Form ref={form} className="admin-panel mt-8 grid gap-5 rounded-2xl p-6">
+    <Form
+      ref={form}
+      onSubmit={(event) => {
+        event.preventDefault();
+        void onSaveClick();
+      }}
+      className="admin-panel mt-8 grid gap-5 rounded-2xl p-6"
+    >
       <FieldContainer label="Name">
         <InputField
           type="text"
@@ -109,18 +123,36 @@ export default function ClientForm(props: Readonly<ClientFormProps>) {
         </SelectField>
       </FieldContainer>
 
+      <FieldContainer label="Monthly budget (SGD)">
+        <InputField
+          type="text"
+          inputMode="decimal"
+          name="monthlyBudget"
+          defaultValue={((props.category?.monthlyBudgetCents ?? 0) / 100).toFixed(2)}
+          required
+          disabled={props.category?.isSystem}
+          className="admin-input"
+        />
+      </FieldContainer>
+
+      <p className="text-sm leading-6 text-admin-muted">
+        Subcategory budgets together cannot exceed their parent category budget.
+        Dashboard budgets are prorated for partial-month date ranges.
+      </p>
+
       <div className="flex justify-between mt-10">
         <FormButton type="button" disabled={pending} onClick={router.back}>
           Cancel
         </FormButton>
-        <FormButton
-          type="submit"
-          disabled={pending}
-          className="text-btn-blue border-btn-blue"
-          onClick={onSaveClick}
-        >
-          Save
-        </FormButton>
+        {!props.category?.isSystem && (
+          <FormButton
+            type="submit"
+            disabled={pending}
+            className="text-btn-blue border-btn-blue"
+          >
+            Save
+          </FormButton>
+        )}
         {props.isNew === false && !props.category?.isSystem && (
           <FormButton
             type="button"

--- a/src/app/admin/money/categories/page.tsx
+++ b/src/app/admin/money/categories/page.tsx
@@ -4,6 +4,7 @@ import PageContainer from "@/components/PageContainer";
 import categoriesService from "@/services/categories.service";
 import Link from "next/link";
 import { Route } from "next";
+import { formatMoney } from "@/features/money/money";
 
 export default async function CategoriesPage() {
   const categories = await categoriesService.getAllCategories();
@@ -37,15 +38,23 @@ export default async function CategoriesPage() {
                     <span className="admin-badge">Default</span>
                   )}
                 </Link>
+                {!category.isSystem && (
+                  <p className="mt-2 text-xs text-admin-muted">
+                    {formatMoney(category.monthlyBudgetCents)} monthly budget
+                  </p>
+                )}
                 {children.length > 0 && (
-                  <div className="mt-4 flex flex-wrap gap-2">
+                  <div className="mt-4 grid gap-2">
                     {children.map((child) => (
                       <Link
                         key={child.id}
                         href={`/admin/money/categories/${child.id}`}
-                        className="admin-chip"
+                        className="flex items-center justify-between rounded-lg border border-admin-line bg-white/4 px-3 py-2 text-sm hover:border-admin-accent/40"
                       >
                         {child.name}
+                        <span className="text-xs text-admin-muted">
+                          {formatMoney(child.monthlyBudgetCents)}
+                        </span>
                       </Link>
                     ))}
                   </div>

--- a/src/app/admin/money/instruments/[id]/ClientForm.tsx
+++ b/src/app/admin/money/instruments/[id]/ClientForm.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import Form from "@/components/Form";
+import { useRouter } from "next/navigation";
+import { SubmitEventHandler, useState } from "react";
+import { createAction, deleteAction, updateAction } from "./actions";
+
+type Instrument = {
+  id: string;
+  name: string;
+  isCreditCard: boolean;
+  transactionCount: number;
+};
+
+export default function ClientForm({
+  instrument,
+}: Readonly<{ instrument?: Instrument | null }>) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const onSubmit: SubmitEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    setPending(true);
+    setError(undefined);
+    const data = new FormData(event.currentTarget);
+    const input = {
+      name: String(data.get("name") ?? ""),
+      isCreditCard: data.get("isCreditCard") === "on",
+    };
+    try {
+      if (instrument) {
+        await updateAction(instrument.id, input);
+        router.refresh();
+      } else {
+        router.push(`/admin/money/instruments/${await createAction(input)}`);
+      }
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not save instrument.");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const onDelete = async () => {
+    if (!instrument || !confirm(`Delete ${instrument.name}?`)) return;
+    setPending(true);
+    setError(undefined);
+    try {
+      await deleteAction(instrument.id);
+      router.push("/admin/money/instruments");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not delete instrument.");
+      setPending(false);
+    }
+  };
+
+  return (
+    <Form onSubmit={onSubmit} className="admin-panel mt-page grid gap-5 rounded-admin p-page">
+      <label className="grid gap-2 text-sm font-medium">
+        Name
+        <input
+          className="admin-input"
+          name="name"
+          maxLength={80}
+          defaultValue={instrument?.name}
+          placeholder="Cash, DBS yuu, PayNow…"
+          required
+        />
+      </label>
+      <label className="flex items-center gap-3 text-sm font-medium">
+        <input
+          type="checkbox"
+          name="isCreditCard"
+          defaultChecked={instrument?.isCreditCard}
+          className="size-4 accent-admin-accent"
+        />
+        This instrument is a credit card
+      </label>
+      <p className="text-sm leading-6 text-admin-muted">
+        Instruments share the primary money balance. Credit-card bill payments are
+        deliberately not recorded as separate transactions.
+      </p>
+      {instrument && (
+        <p className="text-xs text-admin-muted">
+          Used by {instrument.transactionCount} transaction
+          {instrument.transactionCount === 1 ? "" : "s"}.
+        </p>
+      )}
+      {error && <p className="text-sm text-rose-300">{error}</p>}
+      <div className="flex flex-wrap justify-between gap-3">
+        <button type="button" className="admin-secondary-button" onClick={() => router.back()}>
+          Cancel
+        </button>
+        <div className="flex gap-3">
+          {instrument && (
+            <button type="button" className="admin-danger-button" onClick={onDelete} disabled={pending}>
+              Delete
+            </button>
+          )}
+          <button type="submit" className="admin-primary-button" disabled={pending}>
+            {pending ? "Saving…" : "Save instrument"}
+          </button>
+        </div>
+      </div>
+    </Form>
+  );
+}

--- a/src/app/admin/money/instruments/[id]/ClientForm.tsx
+++ b/src/app/admin/money/instruments/[id]/ClientForm.tsx
@@ -25,7 +25,7 @@ export default function ClientForm({
     setError(undefined);
     const data = new FormData(event.currentTarget);
     const input = {
-      name: String(data.get("name") ?? ""),
+      name: String((data.get("name") as string) ?? ""),
       isCreditCard: data.get("isCreditCard") === "on",
     };
     try {
@@ -36,7 +36,9 @@ export default function ClientForm({
         router.push(`/admin/money/instruments/${await createAction(input)}`);
       }
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Could not save instrument.");
+      setError(
+        cause instanceof Error ? cause.message : "Could not save instrument.",
+      );
     } finally {
       setPending(false);
     }
@@ -50,13 +52,18 @@ export default function ClientForm({
       await deleteAction(instrument.id);
       router.push("/admin/money/instruments");
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Could not delete instrument.");
+      setError(
+        cause instanceof Error ? cause.message : "Could not delete instrument.",
+      );
       setPending(false);
     }
   };
 
   return (
-    <Form onSubmit={onSubmit} className="admin-panel mt-page grid gap-5 rounded-admin p-page">
+    <Form
+      onSubmit={onSubmit}
+      className="admin-panel mt-page grid gap-5 rounded-admin p-page"
+    >
       <label className="grid gap-2 text-sm font-medium">
         Name
         <input
@@ -78,8 +85,8 @@ export default function ClientForm({
         This instrument is a credit card
       </label>
       <p className="text-sm leading-6 text-admin-muted">
-        Instruments share the primary money balance. Credit-card bill payments are
-        deliberately not recorded as separate transactions.
+        Instruments share the primary money balance. Credit-card bill payments
+        are deliberately not recorded as separate transactions.
       </p>
       {instrument && (
         <p className="text-xs text-admin-muted">
@@ -89,16 +96,29 @@ export default function ClientForm({
       )}
       {error && <p className="text-sm text-rose-300">{error}</p>}
       <div className="flex flex-wrap justify-between gap-3">
-        <button type="button" className="admin-secondary-button" onClick={() => router.back()}>
+        <button
+          type="button"
+          className="admin-secondary-button"
+          onClick={() => router.back()}
+        >
           Cancel
         </button>
         <div className="flex gap-3">
           {instrument && (
-            <button type="button" className="admin-danger-button" onClick={onDelete} disabled={pending}>
+            <button
+              type="button"
+              className="admin-danger-button"
+              onClick={onDelete}
+              disabled={pending}
+            >
               Delete
             </button>
           )}
-          <button type="submit" className="admin-primary-button" disabled={pending}>
+          <button
+            type="submit"
+            className="admin-primary-button"
+            disabled={pending}
+          >
             {pending ? "Saving…" : "Save instrument"}
           </button>
         </div>

--- a/src/app/admin/money/instruments/[id]/actions.ts
+++ b/src/app/admin/money/instruments/[id]/actions.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import authService from "@/services/auth-service";
+import instrumentsService from "@/services/instruments.service";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+const instrumentSchema = z.object({
+  name: z.string().trim().min(1).max(80),
+  isCreditCard: z.boolean(),
+});
+
+const parse = (input: { name: string; isCreditCard: boolean }) =>
+  instrumentSchema.parse(input);
+
+export const createAction = async (input: {
+  name: string;
+  isCreditCard: boolean;
+}) => {
+  await authService.requireAuthenticatedUser();
+  const dto = parse(input);
+  if (await instrumentsService.nameExists(dto.name)) {
+    throw new Error("An instrument with that name already exists.");
+  }
+  const created = await instrumentsService.create(dto);
+  revalidatePath("/admin/money/instruments");
+  return created.id;
+};
+
+export const updateAction = async (
+  id: string,
+  input: { name: string; isCreditCard: boolean },
+) => {
+  await authService.requireAuthenticatedUser();
+  const dto = parse(input);
+  if (await instrumentsService.nameExists(dto.name, id)) {
+    throw new Error("An instrument with that name already exists.");
+  }
+  await instrumentsService.update(id, dto);
+  revalidatePath("/admin/money/instruments");
+  revalidatePath("/admin/money/transactions");
+};
+
+export const deleteAction = async (id: string) => {
+  await authService.requireAuthenticatedUser();
+  await instrumentsService.delete(id);
+  revalidatePath("/admin/money/instruments");
+};

--- a/src/app/admin/money/instruments/[id]/page.tsx
+++ b/src/app/admin/money/instruments/[id]/page.tsx
@@ -1,0 +1,38 @@
+import TopNavigator from "@/components/HomeButton";
+import PageContainer from "@/components/PageContainer";
+import instrumentsService from "@/services/instruments.service";
+import { notFound } from "next/navigation";
+import ClientForm from "./ClientForm";
+
+export default async function InstrumentPage({
+  params,
+}: Readonly<{ params: Promise<{ id: string }> }>) {
+  const { id } = await params;
+  const isNew = id === "new";
+  const instrument = isNew ? null : await instrumentsService.getById(id);
+  if (!isNew && !instrument) notFound();
+
+  return (
+    <main className="admin-shell min-h-screen">
+      <PageContainer className="mx-auto max-w-2xl">
+        <TopNavigator links={["home", "money"]} />
+        <p className="admin-eyebrow mt-10">Money settings</p>
+        <h1 className="mt-2 text-3xl font-semibold">
+          {isNew ? "New instrument" : instrument?.name}
+        </h1>
+        <ClientForm
+          instrument={
+            instrument
+              ? {
+                  id: instrument.id,
+                  name: instrument.name,
+                  isCreditCard: instrument.isCreditCard,
+                  transactionCount: instrument._count.transactions,
+                }
+              : null
+          }
+        />
+      </PageContainer>
+    </main>
+  );
+}

--- a/src/app/admin/money/instruments/page.tsx
+++ b/src/app/admin/money/instruments/page.tsx
@@ -1,0 +1,49 @@
+import FloatingAction from "@/components/FloatingAction";
+import TopNavigator from "@/components/HomeButton";
+import PageContainer from "@/components/PageContainer";
+import instrumentsService from "@/services/instruments.service";
+import Link from "next/link";
+import { Route } from "next";
+
+export default async function InstrumentsPage() {
+  const defaultInstrument = await instrumentsService.getDefault();
+  const instruments = await instrumentsService.getAll();
+
+  return (
+    <main className="admin-shell min-h-screen">
+      <PageContainer className="mx-auto max-w-4xl">
+        <TopNavigator links={["home", "money"]} />
+        <div className="mt-10 flex items-end justify-between gap-4">
+          <div>
+            <p className="admin-eyebrow">Sources and destinations</p>
+            <h1 className="mt-2 text-3xl font-semibold">Instruments</h1>
+          </div>
+          <span className="text-sm text-admin-muted">{instruments.length} total</span>
+        </div>
+        <div className="mt-page grid gap-3">
+          {instruments.map((instrument) => (
+            <Link
+              key={instrument.id}
+              href={`/admin/money/instruments/${instrument.id}`}
+              className="admin-panel flex items-center justify-between rounded-admin p-page hover:border-admin-accent/40"
+            >
+              <div>
+                <div className="flex items-center gap-2 font-semibold">
+                  {instrument.name}
+                  {instrument.id === defaultInstrument.id && <span className="admin-badge">Default</span>}
+                  {instrument.isCreditCard && <span className="admin-chip">Credit card</span>}
+                </div>
+                <p className="mt-1 text-xs text-admin-muted">
+                  {instrument._count.transactions} transaction
+                  {instrument._count.transactions === 1 ? "" : "s"}
+                </p>
+              </div>
+              <span aria-hidden="true" className="text-admin-muted">→</span>
+            </Link>
+          ))}
+        </div>
+        <FloatingAction href={"/admin/money/instruments/new" as Route}>+</FloatingAction>
+      </PageContainer>
+    </main>
+  );
+}

--- a/src/app/admin/money/page.tsx
+++ b/src/app/admin/money/page.tsx
@@ -14,7 +14,8 @@ export default function MoneyPage() {
       <div className="grid grid-cols-2 gap-4 items-center">
         <AppCard href="/admin/money/transactions">Transactions</AppCard>
         <AppCard href="/admin/money/categories">Categories</AppCard>
-        <AppCard href="/admin/money/settings">Opening Balance</AppCard>
+        <AppCard href="/admin/money/instruments">Instruments</AppCard>
+        <AppCard href="/admin/money/settings">Settings</AppCard>
       </div>
     </PageContainer>
     </main>

--- a/src/app/admin/money/settings/BalanceForm.tsx
+++ b/src/app/admin/money/settings/BalanceForm.tsx
@@ -13,7 +13,7 @@ export default function BalanceForm({
   return (
     <form
       action={action}
-      className="admin-panel mt-8 grid gap-5 rounded-2xl p-6"
+      className="admin-panel grid gap-5 rounded-admin p-page"
     >
       <label className="grid gap-2 text-sm font-medium">
         Opening balance (SGD)

--- a/src/app/admin/money/settings/DefaultInstrumentForm.tsx
+++ b/src/app/admin/money/settings/DefaultInstrumentForm.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useActionState } from "react";
+import { updateDefaultInstrumentAction } from "./actions";
+
+export default function DefaultInstrumentForm({
+  instruments,
+  defaultInstrumentId,
+}: Readonly<{
+  instruments: { id: string; name: string; isCreditCard: boolean }[];
+  defaultInstrumentId: string;
+}>) {
+  const [state, action, pending] = useActionState(
+    updateDefaultInstrumentAction,
+    {},
+  );
+  return (
+    <form action={action} className="admin-panel grid gap-5 rounded-admin p-page">
+      <div>
+        <h2 className="font-semibold">Default instrument</h2>
+        <p className="mt-1 text-sm text-admin-muted">
+          New transactions select this source or destination automatically.
+        </p>
+      </div>
+      <select
+        className="admin-input"
+        name="defaultInstrumentId"
+        defaultValue={defaultInstrumentId}
+      >
+        {instruments.map((instrument) => (
+          <option key={instrument.id} value={instrument.id}>
+            {instrument.name}{instrument.isCreditCard ? " · credit card" : ""}
+          </option>
+        ))}
+      </select>
+      {state.error && <p className="text-sm text-rose-300">{state.error}</p>}
+      {state.success && <p className="text-sm text-emerald-300">{state.success}</p>}
+      <button type="submit" className="admin-primary-button justify-self-start" disabled={pending}>
+        {pending ? "Saving…" : "Save default instrument"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/money/settings/actions.ts
+++ b/src/app/admin/money/settings/actions.ts
@@ -3,6 +3,7 @@
 import { parseMoneyToCents } from "@/features/money/money";
 import authService from "@/services/auth-service";
 import transactionsService from "@/services/transactions.service";
+import instrumentsService from "@/services/instruments.service";
 import { revalidatePath } from "next/cache";
 
 export type BalanceState = { error?: string; success?: string };
@@ -24,5 +25,26 @@ export const updateOpeningBalanceAction = async (
     return { success: "Opening balance updated." };
   } catch (error) {
     return { error: error instanceof Error ? error.message : "Could not update balance." };
+  }
+};
+
+export const updateDefaultInstrumentAction = async (
+  _previousState: BalanceState,
+  formData: FormData,
+): Promise<BalanceState> => {
+  await authService.requireAuthenticatedUser();
+  const id = formData.get("defaultInstrumentId");
+  if (typeof id !== "string" || !id) {
+    return { error: "Choose a default instrument." };
+  }
+  try {
+    await instrumentsService.setDefault(id);
+    revalidatePath("/admin/money/settings");
+    revalidatePath("/admin/money/transactions/new");
+    return { success: "Default instrument updated." };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : "Could not update instrument.",
+    };
   }
 };

--- a/src/app/admin/money/settings/page.tsx
+++ b/src/app/admin/money/settings/page.tsx
@@ -2,16 +2,32 @@ import TopNavigator from "@/components/HomeButton";
 import PageContainer from "@/components/PageContainer";
 import transactionsService from "@/services/transactions.service";
 import BalanceForm from "./BalanceForm";
+import instrumentsService from "@/services/instruments.service";
+import DefaultInstrumentForm from "./DefaultInstrumentForm";
 
 export default async function MoneySettingsPage() {
-  const openingBalanceCents = await transactionsService.getOpeningBalanceCents();
+  const defaultInstrument = await instrumentsService.getDefault();
+  const [openingBalanceCents, instruments] = await Promise.all([
+    transactionsService.getOpeningBalanceCents(),
+    instrumentsService.getAll(),
+  ]);
   return (
     <main className="admin-shell min-h-screen">
       <PageContainer className="mx-auto max-w-2xl">
         <TopNavigator links={["home", "money"]} />
         <p className="admin-eyebrow mt-10">Account setup</p>
-        <h1 className="mt-2 text-3xl font-semibold">Opening balance</h1>
-        <BalanceForm openingBalanceCents={openingBalanceCents} />
+        <h1 className="mt-2 text-3xl font-semibold">Money settings</h1>
+        <div className="mt-page grid gap-page">
+          <BalanceForm openingBalanceCents={openingBalanceCents} />
+          <DefaultInstrumentForm
+            instruments={instruments.map(({ id, name, isCreditCard }) => ({
+              id,
+              name,
+              isCreditCard,
+            }))}
+            defaultInstrumentId={defaultInstrument.id}
+          />
+        </div>
       </PageContainer>
     </main>
   );

--- a/src/app/admin/money/transactions/MoneyCharts.tsx
+++ b/src/app/admin/money/transactions/MoneyCharts.tsx
@@ -1,110 +1,122 @@
 "use client";
 
+import { formatMoney } from "@/features/money/money";
+import { useState } from "react";
 import {
-  Area,
-  AreaChart,
   Bar,
   BarChart,
   CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
 
-type MonthlyPoint = { month: string; income: number; expense: number };
-type CategoryPoint = { category: string; expense: number };
+export type MoneyLinePoint = { period: string } & Record<string, string | number>;
+export type MoneyLineSeries = { key: string; label: string; color: string };
+export type MoneyBarPoint = { category: string; actualCents: number; budgetCents: number };
+
+const tooltipStyle = {
+  background: "#0f1f1a",
+  border: "1px solid rgba(148,163,184,.2)",
+  borderRadius: 12,
+};
+
+const moneyTooltip = (value: unknown) => [
+  formatMoney(Number(value ?? 0)),
+  "",
+];
 
 export default function MoneyCharts({
-  monthly,
-  categories,
+  lineData,
+  lineSeries,
+  barData,
+  showLine,
 }: Readonly<{
-  monthly: MonthlyPoint[];
-  categories: CategoryPoint[];
+  lineData: MoneyLinePoint[];
+  lineSeries: MoneyLineSeries[];
+  barData: MoneyBarPoint[];
+  showLine: boolean;
 }>) {
-  return (
-    <div className="grid gap-5 xl:grid-cols-2">
-      <section className="admin-panel rounded-2xl p-5">
-        <h2 className="font-semibold">Cash flow by month</h2>
-        <p className="mt-1 text-xs text-slate-400">Income versus expenses</p>
-        <div className="mt-5 h-72">
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={monthly}>
-              <defs>
-                <linearGradient id="income" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#34d399" stopOpacity={0.4} />
-                  <stop offset="95%" stopColor="#34d399" stopOpacity={0} />
-                </linearGradient>
-                <linearGradient id="expense" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#fb7185" stopOpacity={0.35} />
-                  <stop offset="95%" stopColor="#fb7185" stopOpacity={0} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid stroke="rgba(148,163,184,.12)" vertical={false} />
-              <XAxis dataKey="month" stroke="#94a3b8" fontSize={12} />
-              <YAxis stroke="#94a3b8" fontSize={12} />
-              <Tooltip
-                formatter={(value) => [
-                  `S$${Number(value ?? 0).toFixed(2)}`,
-                  "",
-                ]}
-                contentStyle={{
-                  background: "#0f1f1a",
-                  border: "1px solid rgba(148,163,184,.2)",
-                  borderRadius: 12,
-                }}
-              />
-              <Area
-                type="monotone"
-                dataKey="income"
-                stroke="#34d399"
-                fill="url(#income)"
-              />
-              <Area
-                type="monotone"
-                dataKey="expense"
-                stroke="#fb7185"
-                fill="url(#expense)"
-              />
-            </AreaChart>
-          </ResponsiveContainer>
-        </div>
-      </section>
+  const [showBudgets, setShowBudgets] = useState(true);
 
-      <section className="admin-panel rounded-2xl p-5">
-        <h2 className="font-semibold">Spending by category</h2>
-        <p className="mt-1 text-xs text-slate-400">Top expense categories</p>
-        <div className="mt-5 h-72">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={categories} layout="vertical" margin={{ left: 16 }}>
-              <CartesianGrid
-                stroke="rgba(148,163,184,.12)"
-                horizontal={false}
+  return (
+    <div className="grid gap-page">
+      {showLine && (
+        <details open className="admin-panel rounded-admin">
+          <summary className="cursor-pointer px-page py-4 font-semibold">
+            Money over time
+          </summary>
+          <div className="h-80 border-t border-admin-line p-page pl-2">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={lineData}>
+                <CartesianGrid stroke="rgba(148,163,184,.12)" vertical={false} />
+                <XAxis dataKey="period" stroke="#92a79d" fontSize={12} />
+                <YAxis
+                  stroke="#92a79d"
+                  fontSize={12}
+                  tickFormatter={(value) => `S$${Math.round(Number(value) / 100)}`}
+                />
+                <Tooltip formatter={moneyTooltip} contentStyle={tooltipStyle} />
+                <Legend />
+                {lineSeries.map((series) => (
+                  <Line
+                    key={series.key}
+                    type="monotone"
+                    dataKey={series.key}
+                    name={series.label}
+                    stroke={series.color}
+                    strokeWidth={2}
+                    dot={lineData.length < 32}
+                    connectNulls
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </details>
+      )}
+
+      {barData.length > 1 && (
+        <details open className="admin-panel rounded-admin">
+          <summary className="cursor-pointer px-page py-4 font-semibold">
+            Categories versus budget
+          </summary>
+          <div className="border-t border-admin-line p-page">
+            <label className="mb-4 flex items-center gap-2 text-xs text-admin-muted">
+              <input
+                type="checkbox"
+                checked={showBudgets}
+                onChange={(event) => setShowBudgets(event.target.checked)}
+                className="accent-admin-accent"
               />
-              <XAxis type="number" stroke="#94a3b8" fontSize={12} />
-              <YAxis
-                type="category"
-                dataKey="category"
-                width={90}
-                stroke="#94a3b8"
-                fontSize={12}
-              />
-              <Tooltip
-                formatter={(value) => [
-                  `S$${Number(value ?? 0).toFixed(2)}`,
-                  "",
-                ]}
-                contentStyle={{
-                  background: "#0f1f1a",
-                  border: "1px solid rgba(148,163,184,.2)",
-                  borderRadius: 12,
-                }}
-              />
-              <Bar dataKey="expense" fill="#fb7185" radius={[0, 6, 6, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </section>
+              Show budget bars
+            </label>
+            <div className="h-80">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={barData}>
+                  <CartesianGrid stroke="rgba(148,163,184,.12)" vertical={false} />
+                  <XAxis dataKey="category" stroke="#92a79d" fontSize={12} />
+                  <YAxis
+                    stroke="#92a79d"
+                    fontSize={12}
+                    tickFormatter={(value) => `S$${Math.round(Number(value) / 100)}`}
+                  />
+                  <Tooltip formatter={moneyTooltip} contentStyle={tooltipStyle} />
+                  <Legend />
+                  <Bar dataKey="actualCents" name="Actual" fill="#fb7185" radius={[6, 6, 0, 0]} />
+                  {showBudgets && (
+                    <Bar dataKey="budgetCents" name="Budget" fill="#6ee7b7" radius={[6, 6, 0, 0]} />
+                  )}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </details>
+      )}
     </div>
   );
 }

--- a/src/app/admin/money/transactions/[id]/actions.ts
+++ b/src/app/admin/money/transactions/[id]/actions.ts
@@ -12,7 +12,8 @@ const transactionSchema = z.object({
   title: z.string().trim().min(1).max(120),
   comments: z.string().trim().max(500),
   time: z.string().min(1),
-  categoryName: z.string().trim().max(80),
+  categoryId: z.string().min(1),
+  instrumentId: z.string().min(1),
 });
 
 const parseEntries = (entries: Record<string, string>) => {
@@ -25,7 +26,8 @@ const parseEntries = (entries: Record<string, string>) => {
     title: parsed.title,
     comments: parsed.comments || null,
     time,
-    categoryName: parsed.categoryName,
+    categoryId: parsed.categoryId,
+    instrumentId: parsed.instrumentId,
   };
 };
 

--- a/src/app/admin/money/transactions/[id]/components/ClientForm.tsx
+++ b/src/app/admin/money/transactions/[id]/components/ClientForm.tsx
@@ -19,13 +19,17 @@ type TransactionFormValue = {
   title: string;
   comments: string | null;
   time: Date;
-  categoryName: string;
+  categoryId: string;
+  instrumentId: string;
 };
 
 type Props = {
   isNew: boolean;
   transaction?: TransactionFormValue | null;
-  categories: { id: string; name: string }[];
+  categories: { id: string; name: string; parentName: string | null }[];
+  defaultCategoryId: string;
+  instruments: { id: string; name: string; isCreditCard: boolean }[];
+  defaultInstrumentId: string;
   currentBalanceCents: number;
   balanceWithoutTransactionCents: number;
 };
@@ -38,9 +42,6 @@ export default function ClientForm(props: Readonly<Props>) {
   );
   const [direction, setDirection] = useState<MoneyDirection>(
     props.transaction?.direction ?? "OUT",
-  );
-  const [categoryName, setCategoryName] = useState(
-    props.transaction?.categoryName ?? "",
   );
   const [error, setError] = useState<string>();
 
@@ -56,11 +57,6 @@ export default function ClientForm(props: Readonly<Props>) {
       return props.balanceWithoutTransactionCents;
     }
   }, [amount, direction, props.balanceWithoutTransactionCents]);
-
-  const categoryExists = props.categories.some(
-    (category) =>
-      category.name.toLowerCase() === categoryName.trim().toLowerCase(),
-  );
 
   const onSubmit: SubmitEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault();
@@ -162,25 +158,45 @@ export default function ClientForm(props: Readonly<Props>) {
 
         <label className="grid gap-2 text-sm font-medium">
           Category
-          <input
+          <select
             className="admin-input"
-            name="categoryName"
-            list="category-options"
-            value={categoryName}
-            maxLength={80}
-            onChange={(event) => setCategoryName(event.target.value)}
-            placeholder="Unclassified"
-          />
-          <datalist id="category-options">
+            name="categoryId"
+            defaultValue={props.transaction?.categoryId ?? props.defaultCategoryId}
+            required
+          >
             {props.categories.map((category) => (
-              <option key={category.id} value={category.name} />
+              <option key={category.id} value={category.id}>
+                {category.parentName
+                  ? `${category.parentName} / ${category.name}`
+                  : category.name}
+              </option>
             ))}
-          </datalist>
-          {categoryName.trim() && !categoryExists && (
-            <span className="text-xs text-amber-200">
-              “{categoryName.trim()}” will be created as a top-level category.
-            </span>
-          )}
+          </select>
+          <span className="text-xs text-admin-muted">
+            Transactions can use subcategories or Unclassified, never a parent category.
+          </span>
+        </label>
+
+        <label className="grid gap-2 text-sm font-medium">
+          Source or destination
+          <select
+            className="admin-input"
+            name="instrumentId"
+            defaultValue={
+              props.transaction?.instrumentId ?? props.defaultInstrumentId
+            }
+            required
+          >
+            {props.instruments.map((instrument) => (
+              <option key={instrument.id} value={instrument.id}>
+                {instrument.name}
+                {instrument.isCreditCard ? " · credit card" : ""}
+              </option>
+            ))}
+          </select>
+          <span className="text-xs text-admin-muted">
+            Instruments describe how money moved; they do not keep separate balances.
+          </span>
         </label>
 
         <label className="grid gap-2 text-sm font-medium">

--- a/src/app/admin/money/transactions/[id]/page.tsx
+++ b/src/app/admin/money/transactions/[id]/page.tsx
@@ -2,6 +2,7 @@ import TopNavigator from "@/components/HomeButton";
 import PageContainer from "@/components/PageContainer";
 import categoriesService from "@/services/categories.service";
 import transactionsService from "@/services/transactions.service";
+import instrumentsService from "@/services/instruments.service";
 import { notFound } from "next/navigation";
 import ClientForm from "./components/ClientForm";
 
@@ -13,9 +14,16 @@ export default async function TransactionPage(
   const transaction = isNew ? null : await transactionsService.getById(id);
   if (!isNew && !transaction) notFound();
 
-  const [categories, currentBalanceCents, balanceWithoutTransactionCents] =
+  const defaultInstrument = await instrumentsService.getDefault();
+  const [
+    categories,
+    instruments,
+    currentBalanceCents,
+    balanceWithoutTransactionCents,
+  ] =
     await Promise.all([
-      categoriesService.getAllCategories(),
+      categoriesService.getSelectableCategories(),
+      instrumentsService.getAll(),
       transactionsService.getBalanceCents(),
       transactionsService.getBalanceCents(transaction?.id),
     ]);
@@ -39,11 +47,25 @@ export default async function TransactionPage(
                   title: transaction.title,
                   comments: transaction.comments,
                   time: transaction.time,
-                  categoryName: transaction.category.name,
+                  categoryId: transaction.categoryId,
+                  instrumentId: transaction.instrumentId,
                 }
               : null
           }
-          categories={categories.map(({ id: categoryId, name }) => ({ id: categoryId, name }))}
+          categories={categories.map(({ id: categoryId, name, parent }) => ({
+            id: categoryId,
+            name,
+            parentName: parent?.name ?? null,
+          }))}
+          defaultCategoryId={
+            categories.find(({ isSystem }) => isSystem)?.id ?? categories[0].id
+          }
+          instruments={instruments.map(({ id: instrumentId, name, isCreditCard }) => ({
+            id: instrumentId,
+            name,
+            isCreditCard,
+          }))}
+          defaultInstrumentId={defaultInstrument.id}
           currentBalanceCents={currentBalanceCents}
           balanceWithoutTransactionCents={balanceWithoutTransactionCents}
         />

--- a/src/app/admin/money/transactions/actions.ts
+++ b/src/app/admin/money/transactions/actions.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import {
+  isMoneyDatePreset,
+  parseMoneyDateEnd,
+  parseMoneyDateStart,
+} from "@/features/money/date-ranges";
+import authService from "@/services/auth-service";
+import savedMoneyFiltersService from "@/services/saved-money-filters.service";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+const filterSchema = z.object({
+  name: z.string().trim().max(80).optional(),
+  direction: z.enum(["IN", "OUT"]),
+  categoryIds: z.array(z.string()).max(10),
+  showSubcategories: z.boolean(),
+  rangePreset: z.string().nullable(),
+  from: z.string().nullable(),
+  to: z.string().nullable(),
+  showCashflow: z.boolean(),
+});
+
+export type SavedFilterInput = z.infer<typeof filterSchema>;
+
+export const saveFilterAction = async (input: SavedFilterInput) => {
+  const user = await authService.requireAuthenticatedUser();
+  const parsed = filterSchema.parse(input);
+  if (parsed.rangePreset && !isMoneyDatePreset(parsed.rangePreset)) {
+    throw new Error("Choose a valid predefined date range.");
+  }
+  const rangePreset =
+    parsed.rangePreset && isMoneyDatePreset(parsed.rangePreset)
+      ? parsed.rangePreset
+      : null;
+  const saved = await savedMoneyFiltersService.create(user.id, {
+    name: parsed.name,
+    direction: parsed.direction,
+    categoryIds: parsed.categoryIds,
+    showSubcategories: parsed.showSubcategories,
+    rangePreset,
+    from: rangePreset ? null : (parseMoneyDateStart(parsed.from ?? undefined) ?? null),
+    to: rangePreset ? null : (parseMoneyDateEnd(parsed.to ?? undefined) ?? null),
+    showCashflow: parsed.showCashflow,
+  });
+  revalidatePath("/admin/money/transactions");
+  return { id: saved.id, name: saved.name };
+};
+
+export const renameFilterAction = async (id: string, name: string) => {
+  const user = await authService.requireAuthenticatedUser();
+  await savedMoneyFiltersService.rename(user.id, id, name);
+  revalidatePath("/admin/money/transactions");
+};
+
+export const deleteFilterAction = async (id: string) => {
+  const user = await authService.requireAuthenticatedUser();
+  await savedMoneyFiltersService.delete(user.id, id);
+  revalidatePath("/admin/money/transactions");
+};

--- a/src/app/admin/money/transactions/components/DashboardFilters.tsx
+++ b/src/app/admin/money/transactions/components/DashboardFilters.tsx
@@ -48,7 +48,8 @@ export type CurrentFilters = {
   showCashflow: boolean;
 };
 
-const unique = (values: string[]) => [...new Set(values)].slice(0, MAX_CATEGORIES);
+const unique = (values: string[]) =>
+  [...new Set(values)].slice(0, MAX_CATEGORIES);
 
 export default function DashboardFilters({
   categories,
@@ -130,7 +131,9 @@ export default function DashboardFilters({
       const room = MAX_CATEGORIES - withoutGroup.length;
       const nextChildren = childIds.slice(0, room);
       if (nextChildren.length < childIds.length) {
-        setError(`The first ${nextChildren.length} subcategories were selected (maximum ${MAX_CATEGORIES}).`);
+        setError(
+          `The first ${nextChildren.length} subcategories were selected (maximum ${MAX_CATEGORIES}).`,
+        );
       }
       return [...withoutGroup, ...nextChildren];
     });
@@ -142,14 +145,17 @@ export default function DashboardFilters({
       const expanded: string[] = [];
       for (const id of selected) {
         const children = childrenByParent.get(id) ?? [];
-        expanded.push(...(children.length ? children.map((child) => child.id) : [id]));
+        expanded.push(
+          ...(children.length ? children.map((child) => child.id) : [id]),
+        );
       }
       setSelected(unique(expanded));
     } else {
       setSelected(
         unique(
           selected.map(
-            (id) => categories.find((category) => category.id === id)?.parentId ?? id,
+            (id) =>
+              categories.find((category) => category.id === id)?.parentId ?? id,
           ),
         ),
       );
@@ -201,7 +207,11 @@ export default function DashboardFilters({
   });
 
   const save = async () => {
-    if (!isValidMoneyDateInput(from) || !isValidMoneyDateInput(to) || from > to) {
+    if (
+      !isValidMoneyDateInput(from) ||
+      !isValidMoneyDateInput(to) ||
+      from > to
+    ) {
       setError("Choose a valid date range with the start before the end.");
       return;
     }
@@ -222,7 +232,9 @@ export default function DashboardFilters({
       setSavedOpen(true);
       router.refresh();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Could not save filter.");
+      setError(
+        cause instanceof Error ? cause.message : "Could not save filter.",
+      );
     } finally {
       setPending(false);
     }
@@ -248,7 +260,9 @@ export default function DashboardFilters({
 
   return (
     <details open className="admin-panel rounded-admin">
-      <summary className="cursor-pointer px-page py-4 font-semibold">Filters</summary>
+      <summary className="cursor-pointer px-page py-4 font-semibold">
+        Filters
+      </summary>
       <div className="grid border-t border-admin-line lg:grid-cols-[18rem_1fr]">
         <aside className="border-b border-admin-line p-4 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:border-r lg:border-b-0">
           <div className="sticky top-0 z-10 bg-admin-surface pb-3">
@@ -260,8 +274,14 @@ export default function DashboardFilters({
               aria-label="Search categories"
             />
             <div className="mt-3 flex items-center justify-between text-xs text-admin-muted">
-              <span>{selected.length} / {MAX_CATEGORIES} selected</span>
-              <button type="button" onClick={() => setSelected([])} className="hover:text-admin-accent">
+              <span>
+                {selected.length} / {MAX_CATEGORIES} selected
+              </span>
+              <button
+                type="button"
+                onClick={() => setSelected([])}
+                className="hover:text-admin-accent"
+              >
                 Clear
               </button>
             </div>
@@ -269,7 +289,9 @@ export default function DashboardFilters({
               <input
                 type="checkbox"
                 checked={showSubcategories}
-                onChange={(event) => changeSubcategoryVisibility(event.target.checked)}
+                onChange={(event) =>
+                  changeSubcategoryVisibility(event.target.checked)
+                }
                 className="accent-admin-accent"
               />
               Show subcategories
@@ -278,7 +300,9 @@ export default function DashboardFilters({
           <div className="grid gap-1">
             {visibleRoots.map((root) => {
               const children = childrenByParent.get(root.id) ?? [];
-              const selectedChildren = children.filter((child) => selected.includes(child.id)).length;
+              const selectedChildren = children.filter((child) =>
+                selected.includes(child.id),
+              ).length;
               const rootSelected = selected.includes(root.id);
               const cue = children.length
                 ? selectedChildren === children.length
@@ -297,7 +321,9 @@ export default function DashboardFilters({
                     className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm font-semibold hover:bg-white/5"
                     aria-label={`${root.name}: ${cue} selected`}
                   >
-                    <span className={`grid size-4 place-items-center rounded border text-[10px] ${cue === "none" ? "border-admin-line" : "border-admin-accent text-admin-accent"}`}>
+                    <span
+                      className={`grid size-4 place-items-center rounded border text-[10px] ${cue === "none" ? "border-admin-line" : "border-admin-accent text-admin-accent"}`}
+                    >
                       {cue === "all" ? "✓" : cue === "some" ? "−" : ""}
                     </span>
                     {root.name}
@@ -305,11 +331,18 @@ export default function DashboardFilters({
                   {showSubcategories && children.length > 0 && (
                     <div className="ml-6 grid gap-1 border-l border-admin-line pl-2">
                       {children
-                        .filter((child) =>
-                          !search.trim() || child.name.toLocaleLowerCase().includes(search.trim().toLocaleLowerCase()),
+                        .filter(
+                          (child) =>
+                            !search.trim() ||
+                            child.name
+                              .toLocaleLowerCase()
+                              .includes(search.trim().toLocaleLowerCase()),
                         )
                         .map((child) => (
-                          <label key={child.id} className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-admin-muted hover:bg-white/5 hover:text-admin-ink">
+                          <label
+                            key={child.id}
+                            className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-admin-muted hover:bg-white/5 hover:text-admin-ink"
+                          >
                             <input
                               type="checkbox"
                               checked={selected.includes(child.id)}
@@ -331,13 +364,24 @@ export default function DashboardFilters({
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="grid gap-2 text-sm font-medium">
               Money direction
-              <select className="admin-input" value={direction} onChange={(event) => setDirection(event.target.value as MoneyDirection)}>
+              <select
+                className="admin-input"
+                value={direction}
+                onChange={(event) =>
+                  setDirection(event.target.value as MoneyDirection)
+                }
+              >
                 <option value="OUT">Money out</option>
                 <option value="IN">Money in</option>
               </select>
             </label>
             <label className="flex items-end gap-3 pb-3 text-sm font-medium">
-              <input type="checkbox" checked={showCashflow} onChange={(event) => setShowCashflow(event.target.checked)} className="size-4 accent-admin-accent" />
+              <input
+                type="checkbox"
+                checked={showCashflow}
+                onChange={(event) => setShowCashflow(event.target.checked)}
+                className="size-4 accent-admin-accent"
+              />
               Include cashflow numbers (money in and out)
             </label>
           </div>
@@ -350,7 +394,11 @@ export default function DashboardFilters({
                   type="button"
                   key={preset}
                   onClick={() => selectPreset(preset)}
-                  className={rangePreset === preset ? "admin-primary-button" : "admin-secondary-button"}
+                  className={
+                    rangePreset === preset
+                      ? "admin-primary-button"
+                      : "admin-secondary-button"
+                  }
                 >
                   {MONEY_DATE_RANGE_LABELS[preset]}
                 </button>
@@ -361,21 +409,45 @@ export default function DashboardFilters({
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="grid gap-2 text-sm font-medium">
               From (inclusive)
-              <input className="admin-input" type="date" value={from} max={to} onChange={(event) => setManualDate("from", event.target.value)} />
+              <input
+                className="admin-input"
+                type="date"
+                value={from}
+                max={to}
+                onChange={(event) => setManualDate("from", event.target.value)}
+              />
             </label>
             <label className="grid gap-2 text-sm font-medium">
               To (inclusive)
-              <input className="admin-input" type="date" value={to} min={from} onChange={(event) => setManualDate("to", event.target.value)} />
+              <input
+                className="admin-input"
+                type="date"
+                value={to}
+                min={from}
+                onChange={(event) => setManualDate("to", event.target.value)}
+              />
             </label>
           </div>
 
-          {error && <p role="alert" className="text-sm text-amber-200">{error}</p>}
+          {error && (
+            <p role="alert" className="text-sm text-amber-200">
+              {error}
+            </p>
+          )}
 
           <div className="flex flex-wrap gap-3">
-            <button type="button" className="admin-primary-button" onClick={() => navigate(active())}>
+            <button
+              type="button"
+              className="admin-primary-button"
+              onClick={() => navigate(active())}
+            >
               Apply filters
             </button>
-            <button type="button" className="admin-secondary-button" onClick={() => setSavedOpen(true)}>
+            <button
+              type="button"
+              className="admin-secondary-button"
+              onClick={() => setSavedOpen(true)}
+            >
               Saved filters ({savedFilters.length})
             </button>
           </div>
@@ -388,7 +460,12 @@ export default function DashboardFilters({
               placeholder="Optional name — Filter 1, Filter 2… if blank"
               maxLength={80}
             />
-            <button type="button" className="admin-secondary-button" onClick={save} disabled={pending}>
+            <button
+              type="button"
+              className="admin-secondary-button"
+              onClick={save}
+              disabled={pending}
+            >
               {pending ? "Saving…" : "Save current filter"}
             </button>
           </div>
@@ -396,11 +473,21 @@ export default function DashboardFilters({
       </div>
 
       {savedOpen && (
-        <div className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4" role="dialog" aria-modal="true" aria-label="Saved filters">
+        <dialog
+          className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4"
+          aria-modal="true"
+          aria-label="Saved filters"
+        >
           <div className="admin-panel max-h-[80vh] w-full max-w-xl overflow-y-auto rounded-admin p-page">
             <div className="flex items-center justify-between gap-4">
               <h2 className="text-xl font-semibold">Saved filters</h2>
-              <button type="button" className="admin-secondary-button" onClick={() => setSavedOpen(false)}>Close</button>
+              <button
+                type="button"
+                className="admin-secondary-button"
+                onClick={() => setSavedOpen(false)}
+              >
+                Close
+              </button>
             </div>
             <div className="mt-page grid gap-3">
               {savedFilters.map((filter) => (
@@ -411,10 +498,14 @@ export default function DashboardFilters({
                   onChanged={() => router.refresh()}
                 />
               ))}
-              {savedFilters.length === 0 && <p className="py-8 text-center text-sm text-admin-muted">No saved filters yet.</p>}
+              {savedFilters.length === 0 && (
+                <p className="py-8 text-center text-sm text-admin-muted">
+                  No saved filters yet.
+                </p>
+              )}
             </div>
           </div>
-        </div>
+        </dialog>
       )}
     </details>
   );
@@ -440,7 +531,9 @@ function SavedFilterRow({
       await renameFilterAction(filter.id, name);
       onChanged();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Could not rename filter.");
+      setError(
+        cause instanceof Error ? cause.message : "Could not rename filter.",
+      );
     } finally {
       setPending(false);
     }
@@ -452,7 +545,9 @@ function SavedFilterRow({
       await deleteFilterAction(filter.id);
       onChanged();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Could not delete filter.");
+      setError(
+        cause instanceof Error ? cause.message : "Could not delete filter.",
+      );
       setPending(false);
     }
   };
@@ -460,16 +555,37 @@ function SavedFilterRow({
   return (
     <div className="rounded-xl border border-admin-line p-3">
       <div className="grid gap-2 sm:grid-cols-[1fr_auto_auto]">
-        <input className="admin-input" value={name} onChange={(event) => setName(event.target.value)} maxLength={80} />
-        <button type="button" className="admin-secondary-button" onClick={rename} disabled={pending || name.trim() === filter.name}>
+        <input
+          className="admin-input"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          maxLength={80}
+        />
+        <button
+          type="button"
+          className="admin-secondary-button"
+          onClick={rename}
+          disabled={pending || name.trim() === filter.name}
+        >
           Rename
         </button>
-        <button type="button" className="admin-danger-button" onClick={remove} disabled={pending} aria-label={`Delete ${filter.name}`}>
+        <button
+          type="button"
+          className="admin-danger-button"
+          onClick={remove}
+          disabled={pending}
+          aria-label={`Delete ${filter.name}`}
+        >
           Delete
         </button>
       </div>
-      <button type="button" onClick={onApply} className="mt-2 w-full rounded-lg px-3 py-2 text-left text-sm text-admin-muted hover:bg-white/5 hover:text-admin-accent">
-        Apply · {filter.direction === "OUT" ? "money out" : "money in"} · {filter.categoryIds.length || "all"} categories
+      <button
+        type="button"
+        onClick={onApply}
+        className="mt-2 w-full rounded-lg px-3 py-2 text-left text-sm text-admin-muted hover:bg-white/5 hover:text-admin-accent"
+      >
+        Apply · {filter.direction === "OUT" ? "money out" : "money in"} ·{" "}
+        {filter.categoryIds.length || "all"} categories
       </button>
       {error && <p className="mt-2 text-xs text-rose-300">{error}</p>}
     </div>

--- a/src/app/admin/money/transactions/components/DashboardFilters.tsx
+++ b/src/app/admin/money/transactions/components/DashboardFilters.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import {
+  getPresetDateRange,
+  MONEY_DATE_RANGE_LABELS,
+  MONEY_DATE_RANGE_PRESETS,
+  MoneyDateRangePreset,
+  isValidMoneyDateInput,
+} from "@/features/money/date-ranges";
+import { MoneyDirection } from "@/features/money/money";
+import { Route } from "next";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import {
+  deleteFilterAction,
+  renameFilterAction,
+  saveFilterAction,
+} from "../actions";
+
+const MAX_CATEGORIES = 10;
+
+export type FilterCategory = {
+  id: string;
+  name: string;
+  parentId: string | null;
+  isSystem: boolean;
+};
+
+export type SavedFilter = {
+  id: string;
+  name: string;
+  direction: MoneyDirection;
+  categoryIds: string[];
+  showSubcategories: boolean;
+  rangePreset: MoneyDateRangePreset | null;
+  from: string | null;
+  to: string | null;
+  showCashflow: boolean;
+};
+
+export type CurrentFilters = {
+  direction: MoneyDirection;
+  categoryIds: string[];
+  showSubcategories: boolean;
+  rangePreset: MoneyDateRangePreset | null;
+  from: string;
+  to: string;
+  showCashflow: boolean;
+};
+
+const unique = (values: string[]) => [...new Set(values)].slice(0, MAX_CATEGORIES);
+
+export default function DashboardFilters({
+  categories,
+  savedFilters,
+  current,
+}: Readonly<{
+  categories: FilterCategory[];
+  savedFilters: SavedFilter[];
+  current: CurrentFilters;
+}>) {
+  const router = useRouter();
+  const [direction, setDirection] = useState(current.direction);
+  const [selected, setSelected] = useState(current.categoryIds);
+  const [showSubcategories, setShowSubcategories] = useState(
+    current.showSubcategories,
+  );
+  const [rangePreset, setRangePreset] = useState(current.rangePreset);
+  const [from, setFrom] = useState(current.from);
+  const [to, setTo] = useState(current.to);
+  const [showCashflow, setShowCashflow] = useState(current.showCashflow);
+  const [search, setSearch] = useState("");
+  const [saveName, setSaveName] = useState("");
+  const [savedOpen, setSavedOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const roots = useMemo(
+    () => categories.filter((category) => !category.parentId),
+    [categories],
+  );
+  const childrenByParent = useMemo(() => {
+    const map = new Map<string, FilterCategory[]>();
+    for (const category of categories) {
+      if (!category.parentId) continue;
+      const children = map.get(category.parentId) ?? [];
+      children.push(category);
+      map.set(category.parentId, children);
+    }
+    return map;
+  }, [categories]);
+
+  const visibleRoots = roots.filter((root) => {
+    const term = search.trim().toLocaleLowerCase();
+    if (!term) return true;
+    return (
+      root.name.toLocaleLowerCase().includes(term) ||
+      (childrenByParent.get(root.id) ?? []).some((child) =>
+        child.name.toLocaleLowerCase().includes(term),
+      )
+    );
+  });
+
+  const toggleSingle = (id: string) => {
+    setError(undefined);
+    setSelected((values) => {
+      if (values.includes(id)) return values.filter((value) => value !== id);
+      if (values.length >= MAX_CATEGORIES) {
+        setError(`Choose no more than ${MAX_CATEGORIES} categories.`);
+        return values;
+      }
+      return [...values, id];
+    });
+  };
+
+  const toggleParent = (root: FilterCategory) => {
+    const children = childrenByParent.get(root.id) ?? [];
+    if (!showSubcategories || children.length === 0) {
+      toggleSingle(root.id);
+      return;
+    }
+    const childIds = children.map(({ id }) => id);
+    const allSelected = childIds.every((id) => selected.includes(id));
+    if (allSelected) {
+      setSelected((values) => values.filter((id) => !childIds.includes(id)));
+      return;
+    }
+    setSelected((values) => {
+      const withoutGroup = values.filter((id) => !childIds.includes(id));
+      const room = MAX_CATEGORIES - withoutGroup.length;
+      const nextChildren = childIds.slice(0, room);
+      if (nextChildren.length < childIds.length) {
+        setError(`The first ${nextChildren.length} subcategories were selected (maximum ${MAX_CATEGORIES}).`);
+      }
+      return [...withoutGroup, ...nextChildren];
+    });
+  };
+
+  const changeSubcategoryVisibility = (show: boolean) => {
+    setShowSubcategories(show);
+    if (show) {
+      const expanded: string[] = [];
+      for (const id of selected) {
+        const children = childrenByParent.get(id) ?? [];
+        expanded.push(...(children.length ? children.map((child) => child.id) : [id]));
+      }
+      setSelected(unique(expanded));
+    } else {
+      setSelected(
+        unique(
+          selected.map(
+            (id) => categories.find((category) => category.id === id)?.parentId ?? id,
+          ),
+        ),
+      );
+    }
+  };
+
+  const selectPreset = (preset: MoneyDateRangePreset) => {
+    const range = getPresetDateRange(preset);
+    setRangePreset(preset);
+    setFrom(range.from);
+    setTo(range.to);
+    if (preset === "THIS_MONTH") setShowCashflow(true);
+  };
+
+  const setManualDate = (side: "from" | "to", value: string) => {
+    setRangePreset(null);
+    if (side === "from") setFrom(value);
+    else setTo(value);
+  };
+
+  const navigate = (filter: CurrentFilters) => {
+    if (
+      !isValidMoneyDateInput(filter.from) ||
+      !isValidMoneyDateInput(filter.to) ||
+      filter.from > filter.to
+    ) {
+      setError("Choose a valid date range with the start before the end.");
+      return;
+    }
+    const params = new URLSearchParams();
+    params.set("direction", filter.direction);
+    filter.categoryIds.forEach((id) => params.append("category", id));
+    params.set("subcategories", filter.showSubcategories ? "show" : "hide");
+    params.set("from", filter.from);
+    params.set("to", filter.to);
+    if (filter.rangePreset) params.set("range", filter.rangePreset);
+    params.set("cashflow", filter.showCashflow ? "true" : "false");
+    router.push(`/admin/money/transactions?${params}` as Route);
+  };
+
+  const active = (): CurrentFilters => ({
+    direction,
+    categoryIds: selected,
+    showSubcategories,
+    rangePreset,
+    from,
+    to,
+    showCashflow,
+  });
+
+  const save = async () => {
+    if (!isValidMoneyDateInput(from) || !isValidMoneyDateInput(to) || from > to) {
+      setError("Choose a valid date range with the start before the end.");
+      return;
+    }
+    setPending(true);
+    setError(undefined);
+    try {
+      await saveFilterAction({
+        name: saveName.trim() || undefined,
+        direction,
+        categoryIds: selected,
+        showSubcategories,
+        rangePreset,
+        from,
+        to,
+        showCashflow,
+      });
+      setSaveName("");
+      setSavedOpen(true);
+      router.refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not save filter.");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const applySaved = (filter: SavedFilter) => {
+    const range = filter.rangePreset
+      ? getPresetDateRange(filter.rangePreset)
+      : { from: filter.from ?? current.from, to: filter.to ?? current.to };
+    setSavedOpen(false);
+    navigate({
+      direction: filter.direction,
+      categoryIds: filter.categoryIds.filter((id) =>
+        categories.some((category) => category.id === id),
+      ),
+      showSubcategories: filter.showSubcategories,
+      rangePreset: filter.rangePreset,
+      from: range.from,
+      to: range.to,
+      showCashflow: filter.showCashflow,
+    });
+  };
+
+  return (
+    <details open className="admin-panel rounded-admin">
+      <summary className="cursor-pointer px-page py-4 font-semibold">Filters</summary>
+      <div className="grid border-t border-admin-line lg:grid-cols-[18rem_1fr]">
+        <aside className="border-b border-admin-line p-4 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:border-r lg:border-b-0">
+          <div className="sticky top-0 z-10 bg-admin-surface pb-3">
+            <input
+              className="admin-input"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search categories"
+              aria-label="Search categories"
+            />
+            <div className="mt-3 flex items-center justify-between text-xs text-admin-muted">
+              <span>{selected.length} / {MAX_CATEGORIES} selected</span>
+              <button type="button" onClick={() => setSelected([])} className="hover:text-admin-accent">
+                Clear
+              </button>
+            </div>
+            <label className="mt-3 flex items-center gap-2 text-xs text-admin-muted">
+              <input
+                type="checkbox"
+                checked={showSubcategories}
+                onChange={(event) => changeSubcategoryVisibility(event.target.checked)}
+                className="accent-admin-accent"
+              />
+              Show subcategories
+            </label>
+          </div>
+          <div className="grid gap-1">
+            {visibleRoots.map((root) => {
+              const children = childrenByParent.get(root.id) ?? [];
+              const selectedChildren = children.filter((child) => selected.includes(child.id)).length;
+              const rootSelected = selected.includes(root.id);
+              const cue = children.length
+                ? selectedChildren === children.length
+                  ? "all"
+                  : selectedChildren
+                    ? "some"
+                    : "none"
+                : rootSelected
+                  ? "all"
+                  : "none";
+              return (
+                <div key={root.id} className="rounded-xl py-1">
+                  <button
+                    type="button"
+                    onClick={() => toggleParent(root)}
+                    className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm font-semibold hover:bg-white/5"
+                    aria-label={`${root.name}: ${cue} selected`}
+                  >
+                    <span className={`grid size-4 place-items-center rounded border text-[10px] ${cue === "none" ? "border-admin-line" : "border-admin-accent text-admin-accent"}`}>
+                      {cue === "all" ? "✓" : cue === "some" ? "−" : ""}
+                    </span>
+                    {root.name}
+                  </button>
+                  {showSubcategories && children.length > 0 && (
+                    <div className="ml-6 grid gap-1 border-l border-admin-line pl-2">
+                      {children
+                        .filter((child) =>
+                          !search.trim() || child.name.toLocaleLowerCase().includes(search.trim().toLocaleLowerCase()),
+                        )
+                        .map((child) => (
+                          <label key={child.id} className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-admin-muted hover:bg-white/5 hover:text-admin-ink">
+                            <input
+                              type="checkbox"
+                              checked={selected.includes(child.id)}
+                              onChange={() => toggleSingle(child.id)}
+                              className="accent-admin-accent"
+                            />
+                            {child.name}
+                          </label>
+                        ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </aside>
+
+        <div className="grid content-start gap-page p-page">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="grid gap-2 text-sm font-medium">
+              Money direction
+              <select className="admin-input" value={direction} onChange={(event) => setDirection(event.target.value as MoneyDirection)}>
+                <option value="OUT">Money out</option>
+                <option value="IN">Money in</option>
+              </select>
+            </label>
+            <label className="flex items-end gap-3 pb-3 text-sm font-medium">
+              <input type="checkbox" checked={showCashflow} onChange={(event) => setShowCashflow(event.target.checked)} className="size-4 accent-admin-accent" />
+              Include cashflow numbers (money in and out)
+            </label>
+          </div>
+
+          <div>
+            <p className="text-sm font-medium">Predefined date range</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {MONEY_DATE_RANGE_PRESETS.map((preset) => (
+                <button
+                  type="button"
+                  key={preset}
+                  onClick={() => selectPreset(preset)}
+                  className={rangePreset === preset ? "admin-primary-button" : "admin-secondary-button"}
+                >
+                  {MONEY_DATE_RANGE_LABELS[preset]}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="grid gap-2 text-sm font-medium">
+              From (inclusive)
+              <input className="admin-input" type="date" value={from} max={to} onChange={(event) => setManualDate("from", event.target.value)} />
+            </label>
+            <label className="grid gap-2 text-sm font-medium">
+              To (inclusive)
+              <input className="admin-input" type="date" value={to} min={from} onChange={(event) => setManualDate("to", event.target.value)} />
+            </label>
+          </div>
+
+          {error && <p role="alert" className="text-sm text-amber-200">{error}</p>}
+
+          <div className="flex flex-wrap gap-3">
+            <button type="button" className="admin-primary-button" onClick={() => navigate(active())}>
+              Apply filters
+            </button>
+            <button type="button" className="admin-secondary-button" onClick={() => setSavedOpen(true)}>
+              Saved filters ({savedFilters.length})
+            </button>
+          </div>
+
+          <div className="grid gap-3 border-t border-admin-line pt-page sm:grid-cols-[1fr_auto]">
+            <input
+              className="admin-input"
+              value={saveName}
+              onChange={(event) => setSaveName(event.target.value)}
+              placeholder="Optional name — Filter 1, Filter 2… if blank"
+              maxLength={80}
+            />
+            <button type="button" className="admin-secondary-button" onClick={save} disabled={pending}>
+              {pending ? "Saving…" : "Save current filter"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {savedOpen && (
+        <div className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4" role="dialog" aria-modal="true" aria-label="Saved filters">
+          <div className="admin-panel max-h-[80vh] w-full max-w-xl overflow-y-auto rounded-admin p-page">
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="text-xl font-semibold">Saved filters</h2>
+              <button type="button" className="admin-secondary-button" onClick={() => setSavedOpen(false)}>Close</button>
+            </div>
+            <div className="mt-page grid gap-3">
+              {savedFilters.map((filter) => (
+                <SavedFilterRow
+                  key={filter.id}
+                  filter={filter}
+                  onApply={() => applySaved(filter)}
+                  onChanged={() => router.refresh()}
+                />
+              ))}
+              {savedFilters.length === 0 && <p className="py-8 text-center text-sm text-admin-muted">No saved filters yet.</p>}
+            </div>
+          </div>
+        </div>
+      )}
+    </details>
+  );
+}
+
+function SavedFilterRow({
+  filter,
+  onApply,
+  onChanged,
+}: Readonly<{
+  filter: SavedFilter;
+  onApply: () => void;
+  onChanged: () => void;
+}>) {
+  const [name, setName] = useState(filter.name);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const rename = async () => {
+    setPending(true);
+    setError(undefined);
+    try {
+      await renameFilterAction(filter.id, name);
+      onChanged();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not rename filter.");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const remove = async () => {
+    setPending(true);
+    try {
+      await deleteFilterAction(filter.id);
+      onChanged();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not delete filter.");
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-admin-line p-3">
+      <div className="grid gap-2 sm:grid-cols-[1fr_auto_auto]">
+        <input className="admin-input" value={name} onChange={(event) => setName(event.target.value)} maxLength={80} />
+        <button type="button" className="admin-secondary-button" onClick={rename} disabled={pending || name.trim() === filter.name}>
+          Rename
+        </button>
+        <button type="button" className="admin-danger-button" onClick={remove} disabled={pending} aria-label={`Delete ${filter.name}`}>
+          Delete
+        </button>
+      </div>
+      <button type="button" onClick={onApply} className="mt-2 w-full rounded-lg px-3 py-2 text-left text-sm text-admin-muted hover:bg-white/5 hover:text-admin-accent">
+        Apply · {filter.direction === "OUT" ? "money out" : "money in"} · {filter.categoryIds.length || "all"} categories
+      </button>
+      {error && <p className="mt-2 text-xs text-rose-300">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/admin/money/transactions/components/Mobile.tsx
+++ b/src/app/admin/money/transactions/components/Mobile.tsx
@@ -12,12 +12,29 @@ export function TransactionRow({
   return (
     <Link
       href={`/admin/money/transactions/${transaction.id}`}
-      className="grid grid-cols-[1.6fr_.8fr_.8fr_.8fr] gap-4 border-b border-white/5 px-5 py-4 text-sm hover:bg-white/5"
+      className="grid grid-cols-[1.4fr_.6fr_.9fr_.8fr_.6fr_.8fr] items-center gap-4 border-b border-white/5 px-5 py-4 text-sm hover:bg-white/5"
     >
-      <span className="font-medium">{transaction.title}</span>
-      <span className="text-slate-400">{transaction.category.name}</span>
-      <span className="text-slate-400">
+      <span className="min-w-0">
+        <span className="block truncate font-medium">{transaction.title}</span>
+        <span className="mt-1 block truncate text-xs text-admin-muted">
+          {transaction.instrument.name}
+        </span>
+      </span>
+      <span className="text-admin-muted">
+        {transaction.direction === "IN" ? "In" : "Out"}
+      </span>
+      <span className="text-admin-muted">
+        {transaction.category.parent
+          ? `${transaction.category.parent.name} / ${transaction.category.name}`
+          : transaction.category.name}
+      </span>
+      <span className="text-admin-muted">
         {transaction.time.toLocaleDateString("en-SG")}
+      </span>
+      <span className="text-admin-muted">
+        {transaction.direction === "OUT" && transaction.category.monthlyBudgetCents > 0
+          ? `${((transaction.amountCents / transaction.category.monthlyBudgetCents) * 100).toFixed(1)}%`
+          : "—"}
       </span>
       <span
         className={`text-right font-semibold ${transaction.direction === "IN" ? "text-emerald-300" : "text-rose-300"}`}
@@ -44,6 +61,9 @@ export function MobileTransaction({
             dateStyle: "medium",
             timeStyle: "short",
           })}
+        </p>
+        <p className="mt-1 truncate text-xs text-admin-muted">
+          {transaction.category.name} · {transaction.instrument.name}
         </p>
       </div>
       <span

--- a/src/app/admin/money/transactions/page.tsx
+++ b/src/app/admin/money/transactions/page.tsx
@@ -1,16 +1,35 @@
 import FloatingAction from "@/components/FloatingAction";
 import TopNavigator from "@/components/HomeButton";
 import PageContainer from "@/components/PageContainer";
-import { formatMoney } from "@/features/money/money";
+import {
+  formatMoneyDateInput,
+  getPresetDateRange,
+  isExactMonthRange,
+  isMoneyDatePreset,
+  isSingleDayRange,
+  isValidMoneyDateInput,
+  MoneyDateRangePreset,
+  parseMoneyDateEnd,
+  parseMoneyDateStart,
+} from "@/features/money/date-ranges";
+import {
+  buildCategorySummaries,
+  buildLineChart,
+  getCategoryGroups,
+} from "@/features/money/dashboard";
+import { formatMoney, MoneyDirection } from "@/features/money/money";
+import authService from "@/services/auth-service";
 import categoriesService from "@/services/categories.service";
+import savedMoneyFiltersService from "@/services/saved-money-filters.service";
 import transactionsService, {
   TransactionFilters,
 } from "@/services/transactions.service";
-import Link from "next/link";
 import { Route } from "next";
-import MoneyCharts from "./MoneyCharts";
-import Stat from "./components/Stat";
+import Link from "next/link";
+import DashboardFilters from "./components/DashboardFilters";
 import { MobileTransaction, TransactionRow } from "./components/Mobile";
+import Stat from "./components/Stat";
+import MoneyCharts from "./MoneyCharts";
 
 const PAGE_SIZE = 12;
 type SearchParams = Record<string, string | string[] | undefined>;
@@ -18,11 +37,8 @@ type SearchParams = Record<string, string | string[] | undefined>;
 const first = (value: string | string[] | undefined) =>
   Array.isArray(value) ? value[0] : value;
 
-const dateAt = (value: string | undefined, endOfDay = false) => {
-  if (!value) return undefined;
-  const date = new Date(`${value}T${endOfDay ? "23:59:59.999" : "00:00:00"}`);
-  return Number.isNaN(date.getTime()) ? undefined : date;
-};
+const many = (value: string | string[] | undefined) =>
+  value ? (Array.isArray(value) ? value : [value]) : [];
 
 export default async function TransactionsPage({
   searchParams,
@@ -31,21 +47,65 @@ export default async function TransactionsPage({
 }>) {
   const query = await searchParams;
   const page = Math.max(1, Number.parseInt(first(query.page) ?? "1", 10) || 1);
-  const direction = first(query.direction);
-  const filters: TransactionFilters = {
-    categoryId: first(query.category),
-    direction:
-      direction === "IN" || direction === "OUT" ? direction : undefined,
-    from: dateAt(first(query.from)),
-    to: dateAt(first(query.to), true),
-    search: first(query.search),
-  };
+  const requestedPreset = first(query.range);
+  const rangePreset: MoneyDateRangePreset | null = isMoneyDatePreset(requestedPreset)
+    ? requestedPreset
+    : first(query.from) || first(query.to)
+      ? null
+      : "THIS_MONTH";
+  const presetRange = rangePreset ? getPresetDateRange(rangePreset) : null;
+  const fallbackRange = getPresetDateRange("THIS_MONTH");
+  const requestedFrom = presetRange?.from ?? first(query.from);
+  const requestedTo = presetRange?.to ?? first(query.to);
+  const hasValidCustomRange =
+    !!requestedFrom &&
+    !!requestedTo &&
+    isValidMoneyDateInput(requestedFrom) &&
+    isValidMoneyDateInput(requestedTo) &&
+    requestedFrom <= requestedTo;
+  const from = hasValidCustomRange ? requestedFrom : fallbackRange.from;
+  const to = hasValidCustomRange ? requestedTo : fallbackRange.to;
+  const direction: MoneyDirection = first(query.direction) === "IN" ? "IN" : "OUT";
+  const showSubcategories = first(query.subcategories) !== "hide";
+  const requestedCashflow = first(query.cashflow);
+  const showCashflow =
+    requestedCashflow === "true"
+      ? true
+      : requestedCashflow === "false"
+        ? false
+        : isExactMonthRange(from, to);
 
-  const [transactions, categories, balanceCents] = await Promise.all([
-    transactionsService.getAll(filters),
+  const [allCategories, balanceCents, user] = await Promise.all([
     categoriesService.getAllCategories(),
     transactionsService.getBalanceCents(),
+    authService.requireAuthenticatedUser(),
   ]);
+  const categoryIds = many(query.category)
+    .filter((id) => allCategories.some((category) => category.id === id))
+    .slice(0, 10);
+  const sortedCategories = [...allCategories].sort((left, right) => {
+    const leftParent = allCategories.find(({ id }) => id === left.parentId)?.name ?? left.name;
+    const rightParent = allCategories.find(({ id }) => id === right.parentId)?.name ?? right.name;
+    return leftParent.localeCompare(rightParent) || left.name.localeCompare(right.name);
+  });
+  const groupResult = getCategoryGroups(
+    sortedCategories,
+    categoryIds,
+    showSubcategories,
+  );
+  const filters: TransactionFilters = {
+    categoryIds: groupResult.filteredCategoryIds,
+    from: parseMoneyDateStart(from),
+    to: parseMoneyDateEnd(to),
+  };
+  const [cashflowTransactions, savedFilters] = await Promise.all([
+    transactionsService.getAll(filters),
+    savedMoneyFiltersService.getAll(user.id),
+  ]);
+  const transactions = cashflowTransactions.filter(
+    (transaction) => transaction.direction === direction,
+  );
+
   const totalPages = Math.max(1, Math.ceil(transactions.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages);
   const descendingPage = transactions.slice(
@@ -56,46 +116,31 @@ export default async function TransactionsPage({
     .reverse()
     .slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
 
-  const incomeCents = transactions
+  const incomeCents = cashflowTransactions
     .filter((transaction) => transaction.direction === "IN")
     .reduce((sum, transaction) => sum + transaction.amountCents, 0);
-  const expenseCents = transactions
+  const expenseCents = cashflowTransactions
     .filter((transaction) => transaction.direction === "OUT")
     .reduce((sum, transaction) => sum + transaction.amountCents, 0);
-
-  const monthlyMap = new Map<string, { income: number; expense: number }>();
-  const categoryMap = new Map<string, number>();
-  for (const transaction of transactions) {
-    const month = transaction.time.toLocaleDateString("en-SG", {
-      month: "short",
-      year: "2-digit",
-    });
-    const monthly = monthlyMap.get(month) ?? { income: 0, expense: 0 };
-    monthly[transaction.direction === "IN" ? "income" : "expense"] +=
-      transaction.amountCents / 100;
-    monthlyMap.set(month, monthly);
-    if (transaction.direction === "OUT") {
-      categoryMap.set(
-        transaction.category.name,
-        (categoryMap.get(transaction.category.name) ?? 0) +
-          transaction.amountCents / 100,
-      );
-    }
-  }
-  const monthly = [...monthlyMap.entries()]
-    .reverse()
-    .slice(-12)
-    .map(([month, values]) => ({ month, ...values }));
-  const categoryChart = [...categoryMap.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 8)
-    .map(([category, expense]) => ({ category, expense }));
+  const directionTotalCents = direction === "IN" ? incomeCents : expenseCents;
+  const savingsCents = incomeCents - expenseCents;
+  const categorySummaries = groupResult.hasCategorySelection
+    ? buildCategorySummaries(transactions, groupResult.groups, from, to)
+    : [];
+  const lineChart = buildLineChart(
+    transactions,
+    groupResult.groups,
+    from,
+    to,
+    false,
+  );
 
   const pageHref = (targetPage: number) => {
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(query)) {
-      if (key !== "page" && typeof value === "string" && value)
-        params.set(key, value);
+      if (key === "page") continue;
+      if (Array.isArray(value)) value.forEach((item) => params.append(key, item));
+      else if (value) params.set(key, value);
     }
     params.set("page", String(targetPage));
     return `/admin/money/transactions?${params}` as Route;
@@ -110,96 +155,119 @@ export default async function TransactionsPage({
             <p className="admin-eyebrow">SGD ledger</p>
             <h1 className="mt-2 text-3xl font-semibold">Transactions</h1>
           </div>
-          <Link
-            href="/admin/money/settings"
-            className="admin-secondary-button hidden md:inline-flex"
-          >
-            Opening balance
+          <Link href="/admin/money/settings" className="admin-secondary-button hidden md:inline-flex">
+            Money settings
           </Link>
         </div>
 
-        <section className="mt-7 hidden gap-4 md:grid md:grid-cols-4">
-          <Stat label="Current balance" value={formatMoney(balanceCents)} />
-          <Stat
-            label="Filtered income"
-            value={formatMoney(incomeCents)}
-            tone="positive"
+        <div className="mt-page hidden md:block">
+          <DashboardFilters
+            key={`${direction}:${categoryIds.join(",")}:${showSubcategories}:${rangePreset}:${from}:${to}:${showCashflow}`}
+            categories={sortedCategories.map(({ id, name, parentId, isSystem }) => ({
+              id,
+              name,
+              parentId,
+              isSystem,
+            }))}
+            savedFilters={savedFilters.map((filter) => ({
+              id: filter.id,
+              name: filter.name,
+              direction: filter.direction,
+              categoryIds: filter.categoryIds,
+              showSubcategories: filter.showSubcategories,
+              rangePreset: filter.rangePreset,
+              from: filter.from ? formatMoneyDateInput(filter.from) : null,
+              to: filter.to ? formatMoneyDateInput(filter.to) : null,
+              showCashflow: filter.showCashflow,
+            }))}
+            current={{
+              direction,
+              categoryIds,
+              showSubcategories,
+              rangePreset,
+              from,
+              to,
+              showCashflow,
+            }}
           />
-          <Stat
-            label="Filtered spending"
-            value={formatMoney(expenseCents)}
-            tone="negative"
-          />
-          <Stat
-            label="Filtered net"
-            value={formatMoney(incomeCents - expenseCents)}
-          />
-        </section>
-
-        <form className="admin-panel mt-5 hidden gap-4 rounded-2xl p-5 md:grid lg:grid-cols-6">
-          <input
-            className="admin-input lg:col-span-2"
-            name="search"
-            placeholder="Search title"
-            defaultValue={first(query.search)}
-          />
-          <select
-            className="admin-input"
-            name="category"
-            defaultValue={first(query.category) ?? ""}
-          >
-            <option value="">All categories</option>
-            {categories.map((category) => (
-              <option key={category.id} value={category.id}>
-                {category.name}
-              </option>
-            ))}
-          </select>
-          <select
-            className="admin-input"
-            name="direction"
-            defaultValue={direction ?? ""}
-          >
-            <option value="">In and out</option>
-            <option value="IN">Money in</option>
-            <option value="OUT">Money out</option>
-          </select>
-          <input
-            className="admin-input"
-            type="date"
-            name="from"
-            aria-label="From date"
-            defaultValue={first(query.from)}
-          />
-          <input
-            className="admin-input"
-            type="date"
-            name="to"
-            aria-label="To date"
-            defaultValue={first(query.to)}
-          />
-          <div className="flex gap-3 lg:col-span-6">
-            <button type="submit" className="admin-primary-button">
-              Apply filters
-            </button>
-            <Link
-              href="/admin/money/transactions"
-              className="admin-secondary-button"
-            >
-              Clear
-            </Link>
-          </div>
-        </form>
-
-        <div className="mt-5 hidden md:block">
-          <MoneyCharts monthly={monthly} categories={categoryChart} />
         </div>
 
-        <section className="admin-panel mt-5 overflow-hidden rounded-2xl">
-          <div className="hidden grid-cols-[1.6fr_.8fr_.8fr_.8fr] gap-4 border-b border-white/10 px-5 py-3 text-xs uppercase tracking-wider text-slate-500 md:grid">
+        <details open className="admin-panel mt-page hidden rounded-admin md:block">
+          <summary className="cursor-pointer px-page py-4 font-semibold">Numbers</summary>
+          <div className="grid gap-4 border-t border-admin-line p-page md:grid-cols-2 xl:grid-cols-4">
+            <Stat label="Current balance" value={formatMoney(balanceCents)} />
+            <Stat
+              label={showCashflow ? "Savings" : direction === "IN" ? "Total money in" : "Total money out"}
+              value={formatMoney(showCashflow ? savingsCents : directionTotalCents)}
+              tone={showCashflow && savingsCents < 0 ? "negative" : direction === "IN" || savingsCents >= 0 ? "positive" : undefined}
+            />
+            {showCashflow && (
+              <>
+                <Stat label="Money in" value={formatMoney(incomeCents)} tone="positive" />
+                <Stat label="Money out" value={formatMoney(expenseCents)} tone="negative" />
+                <Stat
+                  label="Savings rate"
+                  value={incomeCents ? `${((savingsCents / incomeCents) * 100).toFixed(1)}%` : "—"}
+                  tone={savingsCents < 0 ? "negative" : "positive"}
+                />
+                <Stat
+                  label="Money out / money in"
+                  value={incomeCents ? `${((expenseCents / incomeCents) * 100).toFixed(1)}%` : "—"}
+                />
+              </>
+            )}
+            {categorySummaries.map((summary) => {
+              const totalCents = transactions
+                .filter(
+                  (transaction) =>
+                    transaction.direction === direction &&
+                    summary.categoryIds.includes(transaction.categoryId),
+                )
+                .reduce((sum, transaction) => sum + transaction.amountCents, 0);
+              return (
+                <div key={summary.id} className="admin-stat-card">
+                  <span>{summary.name}</span>
+                  <strong>{formatMoney(totalCents)}</strong>
+                  {direction === "OUT" && (
+                    <small className={summary.remainingCents < 0 ? "text-rose-300" : "text-admin-muted"}>
+                      {summary.budgetCents > 0
+                        ? `${summary.remainingCents < 0 ? "Over" : "Remaining"} ${formatMoney(Math.abs(summary.remainingCents))} (${Math.abs(summary.remainingPercentage ?? 0).toFixed(1)}%)`
+                        : "No monthly budget"}
+                    </small>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </details>
+
+        <div className="mt-page hidden md:block">
+          <MoneyCharts
+            lineData={lineChart.data}
+            lineSeries={lineChart.series}
+            barData={
+              direction === "OUT"
+                ? categorySummaries.map(({ name, actualCents, budgetCents }) => ({
+                    category: name,
+                    actualCents,
+                    budgetCents,
+                  }))
+                : []
+            }
+            showLine={!isSingleDayRange(from, to)}
+          />
+        </div>
+
+        <details open className="admin-panel mt-page overflow-hidden rounded-admin">
+          <summary className="hidden cursor-pointer px-page py-4 font-semibold md:block">
+            Transactions ({transactions.length})
+          </summary>
+          <div className="hidden grid-cols-[1.4fr_.6fr_.9fr_.8fr_.6fr_.8fr] gap-4 border-y border-admin-line px-5 py-3 text-xs uppercase tracking-wider text-admin-muted md:grid">
             <span>Transaction</span>
+            <span>Direction</span>
             <span>Category</span>
             <span>Date</span>
+            <span>Budget</span>
             <span className="text-right">Amount</span>
           </div>
           <div className="hidden md:block">
@@ -207,20 +275,17 @@ export default async function TransactionsPage({
               <TransactionRow key={transaction.id} transaction={transaction} />
             ))}
           </div>
-          <div className="divide-y divide-white/10 md:hidden">
+          <div className="divide-y divide-admin-line md:hidden">
             {ascendingPage.map((transaction) => (
-              <MobileTransaction
-                key={transaction.id}
-                transaction={transaction}
-              />
+              <MobileTransaction key={transaction.id} transaction={transaction} />
             ))}
           </div>
           {transactions.length === 0 && (
-            <p className="p-8 text-center text-sm text-slate-400">
+            <p className="p-8 text-center text-sm text-admin-muted">
               No transactions match these filters.
             </p>
           )}
-        </section>
+        </details>
 
         <div className="mt-5 flex items-center justify-between text-sm">
           <Link
@@ -229,9 +294,7 @@ export default async function TransactionsPage({
           >
             Previous
           </Link>
-          <span className="text-slate-400">
-            Page {safePage} of {totalPages}
-          </span>
+          <span className="text-admin-muted">Page {safePage} of {totalPages}</span>
           <Link
             className={`admin-secondary-button ${safePage === totalPages ? "pointer-events-none opacity-40" : ""}`}
             href={pageHref(Math.min(totalPages, safePage + 1))}
@@ -240,9 +303,7 @@ export default async function TransactionsPage({
           </Link>
         </div>
 
-        <FloatingAction href={"/admin/money/transactions/new" as Route}>
-          +
-        </FloatingAction>
+        <FloatingAction href={"/admin/money/transactions/new" as Route}>+</FloatingAction>
       </PageContainer>
     </main>
   );

--- a/src/app/admin/money/transactions/page.tsx
+++ b/src/app/admin/money/transactions/page.tsx
@@ -37,8 +37,10 @@ type SearchParams = Record<string, string | string[] | undefined>;
 const first = (value: string | string[] | undefined) =>
   Array.isArray(value) ? value[0] : value;
 
-const many = (value: string | string[] | undefined) =>
-  value ? (Array.isArray(value) ? value : [value]) : [];
+const many = (value: string | string[] | undefined) => {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+};
 
 export default async function TransactionsPage({
   searchParams,
@@ -48,7 +50,9 @@ export default async function TransactionsPage({
   const query = await searchParams;
   const page = Math.max(1, Number.parseInt(first(query.page) ?? "1", 10) || 1);
   const requestedPreset = first(query.range);
-  const rangePreset: MoneyDateRangePreset | null = isMoneyDatePreset(requestedPreset)
+  const rangePreset: MoneyDateRangePreset | null = isMoneyDatePreset(
+    requestedPreset,
+  )
     ? requestedPreset
     : first(query.from) || first(query.to)
       ? null
@@ -65,7 +69,8 @@ export default async function TransactionsPage({
     requestedFrom <= requestedTo;
   const from = hasValidCustomRange ? requestedFrom : fallbackRange.from;
   const to = hasValidCustomRange ? requestedTo : fallbackRange.to;
-  const direction: MoneyDirection = first(query.direction) === "IN" ? "IN" : "OUT";
+  const direction: MoneyDirection =
+    first(query.direction) === "IN" ? "IN" : "OUT";
   const showSubcategories = first(query.subcategories) !== "hide";
   const requestedCashflow = first(query.cashflow);
   const showCashflow =
@@ -84,9 +89,14 @@ export default async function TransactionsPage({
     .filter((id) => allCategories.some((category) => category.id === id))
     .slice(0, 10);
   const sortedCategories = [...allCategories].sort((left, right) => {
-    const leftParent = allCategories.find(({ id }) => id === left.parentId)?.name ?? left.name;
-    const rightParent = allCategories.find(({ id }) => id === right.parentId)?.name ?? right.name;
-    return leftParent.localeCompare(rightParent) || left.name.localeCompare(right.name);
+    const leftParent =
+      allCategories.find(({ id }) => id === left.parentId)?.name ?? left.name;
+    const rightParent =
+      allCategories.find(({ id }) => id === right.parentId)?.name ?? right.name;
+    return (
+      leftParent.localeCompare(rightParent) ||
+      left.name.localeCompare(right.name)
+    );
   });
   const groupResult = getCategoryGroups(
     sortedCategories,
@@ -139,7 +149,8 @@ export default async function TransactionsPage({
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(query)) {
       if (key === "page") continue;
-      if (Array.isArray(value)) value.forEach((item) => params.append(key, item));
+      if (Array.isArray(value))
+        value.forEach((item) => params.append(key, item));
       else if (value) params.set(key, value);
     }
     params.set("page", String(targetPage));
@@ -155,7 +166,10 @@ export default async function TransactionsPage({
             <p className="admin-eyebrow">SGD ledger</p>
             <h1 className="mt-2 text-3xl font-semibold">Transactions</h1>
           </div>
-          <Link href="/admin/money/settings" className="admin-secondary-button hidden md:inline-flex">
+          <Link
+            href="/admin/money/settings"
+            className="admin-secondary-button hidden md:inline-flex"
+          >
             Money settings
           </Link>
         </div>
@@ -163,12 +177,14 @@ export default async function TransactionsPage({
         <div className="mt-page hidden md:block">
           <DashboardFilters
             key={`${direction}:${categoryIds.join(",")}:${showSubcategories}:${rangePreset}:${from}:${to}:${showCashflow}`}
-            categories={sortedCategories.map(({ id, name, parentId, isSystem }) => ({
-              id,
-              name,
-              parentId,
-              isSystem,
-            }))}
+            categories={sortedCategories.map(
+              ({ id, name, parentId, isSystem }) => ({
+                id,
+                name,
+                parentId,
+                isSystem,
+              }),
+            )}
             savedFilters={savedFilters.map((filter) => ({
               id: filter.id,
               name: filter.name,
@@ -192,27 +208,62 @@ export default async function TransactionsPage({
           />
         </div>
 
-        <details open className="admin-panel mt-page hidden rounded-admin md:block">
-          <summary className="cursor-pointer px-page py-4 font-semibold">Numbers</summary>
+        <details
+          open
+          className="admin-panel mt-page hidden rounded-admin md:block"
+        >
+          <summary className="cursor-pointer px-page py-4 font-semibold">
+            Numbers
+          </summary>
           <div className="grid gap-4 border-t border-admin-line p-page md:grid-cols-2 xl:grid-cols-4">
             <Stat label="Current balance" value={formatMoney(balanceCents)} />
             <Stat
-              label={showCashflow ? "Savings" : direction === "IN" ? "Total money in" : "Total money out"}
-              value={formatMoney(showCashflow ? savingsCents : directionTotalCents)}
-              tone={showCashflow && savingsCents < 0 ? "negative" : direction === "IN" || savingsCents >= 0 ? "positive" : undefined}
+              label={
+                showCashflow
+                  ? "Savings"
+                  : direction === "IN"
+                    ? "Total money in"
+                    : "Total money out"
+              }
+              value={formatMoney(
+                showCashflow ? savingsCents : directionTotalCents,
+              )}
+              tone={
+                showCashflow && savingsCents < 0
+                  ? "negative"
+                  : direction === "IN" || savingsCents >= 0
+                    ? "positive"
+                    : undefined
+              }
             />
             {showCashflow && (
               <>
-                <Stat label="Money in" value={formatMoney(incomeCents)} tone="positive" />
-                <Stat label="Money out" value={formatMoney(expenseCents)} tone="negative" />
+                <Stat
+                  label="Money in"
+                  value={formatMoney(incomeCents)}
+                  tone="positive"
+                />
+                <Stat
+                  label="Money out"
+                  value={formatMoney(expenseCents)}
+                  tone="negative"
+                />
                 <Stat
                   label="Savings rate"
-                  value={incomeCents ? `${((savingsCents / incomeCents) * 100).toFixed(1)}%` : "—"}
+                  value={
+                    incomeCents
+                      ? `${((savingsCents / incomeCents) * 100).toFixed(1)}%`
+                      : "—"
+                  }
                   tone={savingsCents < 0 ? "negative" : "positive"}
                 />
                 <Stat
                   label="Money out / money in"
-                  value={incomeCents ? `${((expenseCents / incomeCents) * 100).toFixed(1)}%` : "—"}
+                  value={
+                    incomeCents
+                      ? `${((expenseCents / incomeCents) * 100).toFixed(1)}%`
+                      : "—"
+                  }
                 />
               </>
             )}
@@ -229,7 +280,13 @@ export default async function TransactionsPage({
                   <span>{summary.name}</span>
                   <strong>{formatMoney(totalCents)}</strong>
                   {direction === "OUT" && (
-                    <small className={summary.remainingCents < 0 ? "text-rose-300" : "text-admin-muted"}>
+                    <small
+                      className={
+                        summary.remainingCents < 0
+                          ? "text-rose-300"
+                          : "text-admin-muted"
+                      }
+                    >
                       {summary.budgetCents > 0
                         ? `${summary.remainingCents < 0 ? "Over" : "Remaining"} ${formatMoney(Math.abs(summary.remainingCents))} (${Math.abs(summary.remainingPercentage ?? 0).toFixed(1)}%)`
                         : "No monthly budget"}
@@ -247,18 +304,23 @@ export default async function TransactionsPage({
             lineSeries={lineChart.series}
             barData={
               direction === "OUT"
-                ? categorySummaries.map(({ name, actualCents, budgetCents }) => ({
-                    category: name,
-                    actualCents,
-                    budgetCents,
-                  }))
+                ? categorySummaries.map(
+                    ({ name, actualCents, budgetCents }) => ({
+                      category: name,
+                      actualCents,
+                      budgetCents,
+                    }),
+                  )
                 : []
             }
             showLine={!isSingleDayRange(from, to)}
           />
         </div>
 
-        <details open className="admin-panel mt-page overflow-hidden rounded-admin">
+        <details
+          open
+          className="admin-panel mt-page overflow-hidden rounded-admin"
+        >
           <summary className="hidden cursor-pointer px-page py-4 font-semibold md:block">
             Transactions ({transactions.length})
           </summary>
@@ -277,7 +339,10 @@ export default async function TransactionsPage({
           </div>
           <div className="divide-y divide-admin-line md:hidden">
             {ascendingPage.map((transaction) => (
-              <MobileTransaction key={transaction.id} transaction={transaction} />
+              <MobileTransaction
+                key={transaction.id}
+                transaction={transaction}
+              />
             ))}
           </div>
           {transactions.length === 0 && (
@@ -294,7 +359,9 @@ export default async function TransactionsPage({
           >
             Previous
           </Link>
-          <span className="text-admin-muted">Page {safePage} of {totalPages}</span>
+          <span className="text-admin-muted">
+            Page {safePage} of {totalPages}
+          </span>
           <Link
             className={`admin-secondary-button ${safePage === totalPages ? "pointer-events-none opacity-40" : ""}`}
             href={pageHref(Math.min(totalPages, safePage + 1))}
@@ -303,7 +370,9 @@ export default async function TransactionsPage({
           </Link>
         </div>
 
-        <FloatingAction href={"/admin/money/transactions/new" as Route}>+</FloatingAction>
+        <FloatingAction href={"/admin/money/transactions/new" as Route}>
+          +
+        </FloatingAction>
       </PageContainer>
     </main>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,21 +41,26 @@ body::-webkit-scrollbar-thumb {
   --color-admin-page: #07110d;
   --color-admin-surface: #0d1b16;
   --color-admin-accent: #6ee7b7;
+  --color-admin-ink: #eef8f3;
+  --color-admin-muted: #92a79d;
+  --color-admin-line: rgba(148, 163, 184, 0.13);
+  --spacing-page: 1.25rem;
+  --radius-admin: 1rem;
 }
 
 .admin-shell {
-  color: #eef8f3;
+  color: var(--color-admin-ink);
   background:
     radial-gradient(circle at 90% -10%, rgba(52, 211, 153, 0.14), transparent 34rem),
     linear-gradient(rgba(255, 255, 255, 0.015) 1px, transparent 1px),
     linear-gradient(90deg, rgba(255, 255, 255, 0.015) 1px, transparent 1px),
-    #07110d;
+    var(--color-admin-page);
   background-size: auto, 64px 64px, 64px 64px, auto;
 }
 
 .admin-panel {
-  background: rgba(13, 27, 22, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.13);
+  background: color-mix(in srgb, var(--color-admin-surface) 92%, transparent);
+  border: 1px solid var(--color-admin-line);
   box-shadow: 0 18px 60px rgba(0, 0, 0, 0.18);
 }
 
@@ -65,7 +70,7 @@ body::-webkit-scrollbar-thumb {
   justify-content: space-between;
   gap: 1rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.13);
+  border-bottom: 1px solid var(--color-admin-line);
 }
 
 .admin-nav-link {
@@ -86,7 +91,7 @@ body::-webkit-scrollbar-thumb {
 }
 
 .admin-eyebrow {
-  color: #6ee7b7;
+  color: var(--color-admin-accent);
   font-size: 0.7rem;
   font-weight: 750;
   letter-spacing: 0.16em;
@@ -97,7 +102,7 @@ body::-webkit-scrollbar-thumb {
   width: 100%;
   min-height: 2.75rem;
   padding: 0.65rem 0.8rem;
-  color: #eef8f3;
+  color: var(--color-admin-ink);
   background: rgba(3, 10, 7, 0.5);
   border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: 0.75rem;
@@ -131,7 +136,7 @@ body::-webkit-scrollbar-thumb {
 
 .admin-primary-button {
   color: #052e22;
-  background: #6ee7b7;
+  background: var(--color-admin-accent);
 }
 
 .admin-secondary-button {
@@ -163,13 +168,13 @@ body::-webkit-scrollbar-thumb {
   display: grid;
   gap: 0.55rem;
   padding: 1.1rem;
-  background: rgba(13, 27, 22, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.13);
+  background: color-mix(in srgb, var(--color-admin-surface) 92%, transparent);
+  border: 1px solid var(--color-admin-line);
   border-radius: 1rem;
 }
 
 .admin-stat-card span {
-  color: #82958c;
+  color: var(--color-admin-muted);
   font-size: 0.72rem;
 }
 

--- a/src/components/PageContainer.tsx
+++ b/src/components/PageContainer.tsx
@@ -3,5 +3,5 @@
  */
 export default function PageContainer(props: React.ComponentProps<"div">) {
   const { className = "", ...rest } = props;
-  return <div {...rest} className={`px-5 py-5 sm:px-6 ${className}`} />;
+  return <div {...rest} className={`px-page py-page sm:px-6 ${className}`} />;
 }

--- a/src/features/money/dashboard.ts
+++ b/src/features/money/dashboard.ts
@@ -1,0 +1,166 @@
+import { formatMoneyDateInput, getBudgetForDateRange } from "./date-ranges";
+
+export type DashboardCategory = {
+  id: string;
+  name: string;
+  parentId: string | null;
+  monthlyBudgetCents: number;
+};
+
+export type DashboardTransaction = {
+  amountCents: number;
+  direction: "IN" | "OUT";
+  time: Date;
+  categoryId: string;
+};
+
+export type CategoryGroup = {
+  id: string;
+  name: string;
+  categoryIds: string[];
+  monthlyBudgetCents: number;
+};
+
+const SERIES_COLORS = [
+  "#6ee7b7",
+  "#fb7185",
+  "#60a5fa",
+  "#fbbf24",
+  "#c084fc",
+  "#22d3ee",
+  "#f97316",
+  "#a3e635",
+  "#f472b6",
+  "#94a3b8",
+];
+
+export const getCategoryGroups = (
+  categories: DashboardCategory[],
+  selectedIds: string[],
+  showSubcategories: boolean,
+) => {
+  const selected = new Set(selectedIds);
+  if (!selected.size) {
+    return {
+      groups: [
+        {
+          id: "all",
+          name: "All money",
+          categoryIds: categories.map(({ id }) => id),
+          monthlyBudgetCents: 0,
+        },
+      ],
+      filteredCategoryIds: [] as string[],
+      hasCategorySelection: false,
+    };
+  }
+
+  const groups: CategoryGroup[] = [];
+  for (const category of categories) {
+    if (!selected.has(category.id)) continue;
+    const children = categories.filter(({ parentId }) => parentId === category.id);
+    groups.push({
+      id: category.id,
+      name: category.name,
+      categoryIds:
+        !showSubcategories && children.length
+          ? [category.id, ...children.map(({ id }) => id)]
+          : [category.id],
+      monthlyBudgetCents: category.monthlyBudgetCents,
+    });
+  }
+
+  return {
+    groups,
+    filteredCategoryIds: [...new Set(groups.flatMap(({ categoryIds }) => categoryIds))],
+    hasCategorySelection: true,
+  };
+};
+
+const getGranularity = (from: string, to: string) => {
+  const days =
+    Math.round(
+      (new Date(`${to}T00:00:00Z`).getTime() -
+        new Date(`${from}T00:00:00Z`).getTime()) /
+        86_400_000,
+    ) + 1;
+  if (days <= 62) return "day" as const;
+  if (days <= 370) return "week" as const;
+  return "month" as const;
+};
+
+const getBucket = (date: Date, granularity: "day" | "week" | "month") => {
+  const singaporeDate = formatMoneyDateInput(date);
+  if (granularity === "day") return singaporeDate;
+  if (granularity === "month") return singaporeDate.slice(0, 7);
+  const value = new Date(`${singaporeDate}T00:00:00Z`);
+  const weekday = value.getUTCDay() || 7;
+  value.setUTCDate(value.getUTCDate() + 1 - weekday);
+  return formatMoneyDateInput(value);
+};
+
+export const buildLineChart = (
+  transactions: DashboardTransaction[],
+  groups: CategoryGroup[],
+  from: string,
+  to: string,
+  showCashflow: boolean,
+) => {
+  const granularity = getGranularity(from, to);
+  const buckets = new Map<string, Record<string, number>>();
+  for (const transaction of transactions) {
+    const group = groups.find(({ categoryIds }) =>
+      categoryIds.includes(transaction.categoryId),
+    );
+    if (!group) continue;
+    const bucket = getBucket(transaction.time, granularity);
+    const values = buckets.get(bucket) ?? {};
+    const key = `series_${groups.indexOf(group)}`;
+    const amount =
+      showCashflow && transaction.direction === "OUT"
+        ? -transaction.amountCents
+        : transaction.amountCents;
+    values[key] = (values[key] ?? 0) + amount;
+    buckets.set(bucket, values);
+  }
+
+  return {
+    data: [...buckets.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([period, values]) => ({ period, ...values })),
+    series: groups.map((group, index) => ({
+      key: `series_${index}`,
+      label: group.name,
+      color: SERIES_COLORS[index % SERIES_COLORS.length],
+    })),
+  };
+};
+
+export const buildCategorySummaries = (
+  transactions: DashboardTransaction[],
+  groups: CategoryGroup[],
+  from: string,
+  to: string,
+) =>
+  groups.map((group) => {
+    const actualCents = transactions
+      .filter(
+        (transaction) =>
+          transaction.direction === "OUT" &&
+          group.categoryIds.includes(transaction.categoryId),
+      )
+      .reduce((sum, transaction) => sum + transaction.amountCents, 0);
+    const budgetCents = getBudgetForDateRange(
+      group.monthlyBudgetCents,
+      from,
+      to,
+    );
+    return {
+      ...group,
+      actualCents,
+      budgetCents,
+      remainingCents: budgetCents - actualCents,
+      remainingPercentage:
+        budgetCents > 0 ? ((budgetCents - actualCents) / budgetCents) * 100 : null,
+    };
+  });

--- a/src/features/money/date-ranges.ts
+++ b/src/features/money/date-ranges.ts
@@ -1,0 +1,150 @@
+export const MONEY_DATE_RANGE_PRESETS = [
+  "TODAY",
+  "THIS_WEEK",
+  "LAST_WEEK",
+  "THIS_MONTH",
+  "LAST_MONTH",
+  "THIS_YEAR",
+  "LAST_YEAR",
+] as const;
+
+export type MoneyDateRangePreset = (typeof MONEY_DATE_RANGE_PRESETS)[number];
+
+export const MONEY_DATE_RANGE_LABELS: Record<MoneyDateRangePreset, string> = {
+  TODAY: "Today",
+  THIS_WEEK: "This week",
+  LAST_WEEK: "Last week",
+  THIS_MONTH: "This month",
+  LAST_MONTH: "Last month",
+  THIS_YEAR: "This year",
+  LAST_YEAR: "Last year",
+};
+
+const SINGAPORE_TIME_ZONE = "Asia/Singapore";
+const SINGAPORE_OFFSET = "+08:00";
+
+const formatDate = (date: Date) =>
+  [
+    date.getUTCFullYear(),
+    String(date.getUTCMonth() + 1).padStart(2, "0"),
+    String(date.getUTCDate()).padStart(2, "0"),
+  ].join("-");
+
+export const formatMoneyDateInput = (date: Date) => {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: SINGAPORE_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const value = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  return `${value("year")}-${value("month")}-${value("day")}`;
+};
+
+const singaporeToday = () => {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: SINGAPORE_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts();
+  const value = (type: Intl.DateTimeFormatPartTypes) =>
+    Number(parts.find((part) => part.type === type)?.value);
+  return new Date(Date.UTC(value("year"), value("month") - 1, value("day")));
+};
+
+const addDays = (date: Date, days: number) => {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+};
+
+export const getPresetDateRange = (preset: MoneyDateRangePreset) => {
+  const today = singaporeToday();
+  const day = today.getUTCDay() || 7;
+  const startOfThisWeek = addDays(today, 1 - day);
+  const year = today.getUTCFullYear();
+  const month = today.getUTCMonth();
+
+  const ranges: Record<MoneyDateRangePreset, [Date, Date]> = {
+    TODAY: [today, today],
+    THIS_WEEK: [startOfThisWeek, addDays(startOfThisWeek, 6)],
+    LAST_WEEK: [addDays(startOfThisWeek, -7), addDays(startOfThisWeek, -1)],
+    THIS_MONTH: [
+      new Date(Date.UTC(year, month, 1)),
+      new Date(Date.UTC(year, month + 1, 0)),
+    ],
+    LAST_MONTH: [
+      new Date(Date.UTC(year, month - 1, 1)),
+      new Date(Date.UTC(year, month, 0)),
+    ],
+    THIS_YEAR: [
+      new Date(Date.UTC(year, 0, 1)),
+      new Date(Date.UTC(year, 11, 31)),
+    ],
+    LAST_YEAR: [
+      new Date(Date.UTC(year - 1, 0, 1)),
+      new Date(Date.UTC(year - 1, 11, 31)),
+    ],
+  };
+  const [from, to] = ranges[preset];
+  return { from: formatDate(from), to: formatDate(to) };
+};
+
+export const parseMoneyDateStart = (value?: string) =>
+  value ? new Date(`${value}T00:00:00.000${SINGAPORE_OFFSET}`) : undefined;
+
+export const parseMoneyDateEnd = (value?: string) =>
+  value ? new Date(`${value}T23:59:59.999${SINGAPORE_OFFSET}`) : undefined;
+
+export const isMoneyDatePreset = (
+  value: string | undefined,
+): value is MoneyDateRangePreset =>
+  MONEY_DATE_RANGE_PRESETS.includes(value as MoneyDateRangePreset);
+
+export const isSingleDayRange = (from: string, to: string) => from === to;
+
+export const isValidMoneyDateInput = (value: string) => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.getTime()) && formatDate(date) === value;
+};
+
+export const isExactMonthRange = (from: string, to: string) => {
+  if (!isValidMoneyDateInput(from) || !isValidMoneyDateInput(to)) return false;
+  const start = new Date(`${from}T00:00:00Z`);
+  const end = new Date(`${to}T00:00:00Z`);
+  return (
+    start.getUTCDate() === 1 &&
+    end.getUTCDate() ===
+      new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth() + 1, 0)).getUTCDate() &&
+    start.getUTCFullYear() === end.getUTCFullYear() &&
+    start.getUTCMonth() === end.getUTCMonth()
+  );
+};
+
+export const getBudgetForDateRange = (
+  monthlyBudgetCents: number,
+  from: string,
+  to: string,
+) => {
+  if (monthlyBudgetCents <= 0) return 0;
+  const cursor = new Date(`${from}T00:00:00Z`);
+  const last = new Date(`${to}T00:00:00Z`);
+  let budget = 0;
+
+  while (cursor <= last) {
+    const year = cursor.getUTCFullYear();
+    const month = cursor.getUTCMonth();
+    const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+    const monthEnd = new Date(Date.UTC(year, month, daysInMonth));
+    const overlapEnd = monthEnd < last ? monthEnd : last;
+    const days =
+      Math.round((overlapEnd.getTime() - cursor.getTime()) / 86_400_000) + 1;
+    budget += (monthlyBudgetCents * days) / daysInMonth;
+    cursor.setUTCMonth(month + 1, 1);
+  }
+
+  return Math.round(budget);
+};

--- a/src/services/categories.service.ts
+++ b/src/services/categories.service.ts
@@ -7,6 +7,7 @@ export const UNCLASSIFIED_CATEGORY_NAME = "Unclassified";
 export type CreateCategoryDto = {
   name: string;
   parentId: string | null;
+  monthlyBudgetCents: number;
 };
 export type UpdateCategoryDto = Partial<CreateCategoryDto>;
 
@@ -45,34 +46,20 @@ export class CategoriesService {
   async createCategory(dto: CreateCategoryDto) {
     const name = cleanName(dto.name);
     if (!name) throw new Error("Category name is required.");
-    if (dto.parentId) await this.validateParent(dto.parentId);
+    this.validateBudgetValue(dto.monthlyBudgetCents);
+    if (dto.parentId) {
+      await this.validateParent(dto.parentId);
+      await this.validateChildBudget(dto.parentId, dto.monthlyBudgetCents);
+    }
 
     return prisma.category.create({
       data: {
         name,
         normalizedName: normalizeName(name),
         parentId: dto.parentId,
+        monthlyBudgetCents: dto.monthlyBudgetCents,
       },
     });
-  }
-
-  async findOrCreateByName(nameInput?: string | null) {
-    const name = cleanName(nameInput ?? "");
-    if (!name) return this.ensureUnclassified();
-
-    const normalizedName = normalizeName(name);
-    const existing = await prisma.category.findFirst({
-      where: {
-        OR: [
-          { normalizedName },
-          { name: { equals: name, mode: "insensitive" } },
-        ],
-      },
-    });
-    return (
-      existing ??
-      prisma.category.create({ data: { name, normalizedName, parentId: null } })
-    );
   }
 
   async updateCategory(id: string, dto: UpdateCategoryDto) {
@@ -84,6 +71,25 @@ export class CategoriesService {
       throw new Error("A category cannot be its own parent.");
     if (dto.parentId) await this.validateParent(dto.parentId);
 
+    const monthlyBudgetCents =
+      dto.monthlyBudgetCents ?? existing.monthlyBudgetCents;
+    this.validateBudgetValue(monthlyBudgetCents);
+    const parentId =
+      dto.parentId === undefined ? existing.parentId : dto.parentId;
+    if (parentId) {
+      if (await this.hasChildCategories(id)) {
+        throw new Error("A parent category cannot become a subcategory.");
+      }
+      await this.validateChildBudget(parentId, monthlyBudgetCents, id);
+    } else {
+      const childrenBudget = await this.getChildrenBudget(id);
+      if (childrenBudget > monthlyBudgetCents) {
+        throw new Error(
+          "The parent budget cannot be less than the sum of its subcategory budgets.",
+        );
+      }
+    }
+
     const name = dto.name === undefined ? undefined : cleanName(dto.name);
     if (name !== undefined && !name)
       throw new Error("Category name is required.");
@@ -94,6 +100,7 @@ export class CategoriesService {
         name,
         normalizedName: name ? normalizeName(name) : undefined,
         parentId: dto.parentId,
+        monthlyBudgetCents: dto.monthlyBudgetCents,
       },
     });
   }
@@ -123,8 +130,31 @@ export class CategoriesService {
   async getAllCategories() {
     await this.ensureUnclassified();
     return prisma.category.findMany({
+      include: { _count: { select: { children: true, transactions: true } } },
       orderBy: [{ isSystem: "desc" }, { name: "asc" }],
     });
+  }
+
+  async getSelectableCategories() {
+    await this.ensureUnclassified();
+    return prisma.category.findMany({
+      where: {
+        OR: [{ isSystem: true }, { parentId: { not: null } }],
+      },
+      include: { parent: true },
+      orderBy: [{ parentId: "asc" }, { name: "asc" }],
+    });
+  }
+
+  async requireSelectableCategory(id: string) {
+    const category = await prisma.category.findUnique({
+      where: { id },
+    });
+    if (!category) throw new Error("Category not found.");
+    if (!category.isSystem && !category.parentId) {
+      throw new Error("Choose a subcategory instead of a parent category.");
+    }
+    return category;
   }
 
   async getAvailableParents(currentId?: string) {
@@ -163,6 +193,43 @@ export class CategoriesService {
       throw new Error("Unclassified cannot have subcategories.");
     if (parent.parentId)
       throw new Error("Subcategories cannot have subcategories.");
+    if ((await prisma.transaction.count({ where: { categoryId: parentId } })) > 0) {
+      throw new Error(
+        "Move the parent category's transactions before adding a subcategory.",
+      );
+    }
+  }
+
+  private validateBudgetValue(monthlyBudgetCents: number) {
+    if (!Number.isSafeInteger(monthlyBudgetCents) || monthlyBudgetCents < 0) {
+      throw new Error("Monthly budget must be zero or a valid positive amount.");
+    }
+  }
+
+  private async getChildrenBudget(parentId: string, exceptId?: string) {
+    const result = await prisma.category.aggregate({
+      where: {
+        parentId,
+        id: exceptId ? { not: exceptId } : undefined,
+      },
+      _sum: { monthlyBudgetCents: true },
+    });
+    return result._sum.monthlyBudgetCents ?? 0;
+  }
+
+  private async validateChildBudget(
+    parentId: string,
+    monthlyBudgetCents: number,
+    exceptId?: string,
+  ) {
+    const parent = await this.getCategoryById(parentId);
+    if (!parent) throw new Error("Parent category not found.");
+    const siblingsBudget = await this.getChildrenBudget(parentId, exceptId);
+    if (siblingsBudget + monthlyBudgetCents > parent.monthlyBudgetCents) {
+      throw new Error(
+        "Subcategory budgets cannot exceed the parent category's monthly budget.",
+      );
+    }
   }
 }
 

--- a/src/services/instruments.service.ts
+++ b/src/services/instruments.service.ts
@@ -1,0 +1,128 @@
+import "server-only";
+
+import prisma from "./prisma-service";
+
+const PRIMARY_ACCOUNT_ID = "primary";
+const DEFAULT_INSTRUMENT_NAME = "Cash";
+
+const cleanName = (name: string) => name.trim().replace(/\s+/g, " ");
+const normalizeName = (name: string) => cleanName(name).toLocaleLowerCase("en-US");
+
+export type SaveInstrumentDto = {
+  name: string;
+  isCreditCard: boolean;
+};
+
+export class InstrumentsService {
+  async ensureDefaultInstrument() {
+    const account = await prisma.moneyAccount.upsert({
+      where: { id: PRIMARY_ACCOUNT_ID },
+      create: { id: PRIMARY_ACCOUNT_ID },
+      update: {},
+      include: { defaultInstrument: true },
+    });
+    if (account.defaultInstrument) return account.defaultInstrument;
+
+    const normalizedName = normalizeName(DEFAULT_INSTRUMENT_NAME);
+    const instrument = await prisma.instrument.upsert({
+      where: { normalizedName },
+      create: {
+        name: DEFAULT_INSTRUMENT_NAME,
+        normalizedName,
+      },
+      update: {},
+    });
+    await prisma.moneyAccount.update({
+      where: { id: PRIMARY_ACCOUNT_ID },
+      data: { defaultInstrumentId: instrument.id },
+    });
+    return instrument;
+  }
+
+  async getAll() {
+    await this.ensureDefaultInstrument();
+    return prisma.instrument.findMany({
+      include: { _count: { select: { transactions: true } } },
+      orderBy: { name: "asc" },
+    });
+  }
+
+  async getById(id: string) {
+    return prisma.instrument.findUnique({
+      where: { id },
+      include: { _count: { select: { transactions: true } } },
+    });
+  }
+
+  async getDefault() {
+    return this.ensureDefaultInstrument();
+  }
+
+  async create(dto: SaveInstrumentDto) {
+    const name = this.validateName(dto.name);
+    return prisma.instrument.create({
+      data: {
+        name,
+        normalizedName: normalizeName(name),
+        isCreditCard: dto.isCreditCard,
+      },
+    });
+  }
+
+  async update(id: string, dto: SaveInstrumentDto) {
+    const name = this.validateName(dto.name);
+    return prisma.instrument.update({
+      where: { id },
+      data: {
+        name,
+        normalizedName: normalizeName(name),
+        isCreditCard: dto.isCreditCard,
+      },
+    });
+  }
+
+  async delete(id: string) {
+    const [transactionCount, accountCount] = await Promise.all([
+      prisma.transaction.count({ where: { instrumentId: id } }),
+      prisma.moneyAccount.count({ where: { defaultInstrumentId: id } }),
+    ]);
+    if (transactionCount > 0) {
+      throw new Error("An instrument used by transactions cannot be deleted.");
+    }
+    if (accountCount > 0) {
+      throw new Error("Choose another default instrument before deleting this one.");
+    }
+    await prisma.instrument.delete({ where: { id } });
+  }
+
+  async setDefault(id: string) {
+    const instrument = await prisma.instrument.findUnique({ where: { id } });
+    if (!instrument) throw new Error("Instrument not found.");
+    await prisma.moneyAccount.upsert({
+      where: { id: PRIMARY_ACCOUNT_ID },
+      create: { id: PRIMARY_ACCOUNT_ID, defaultInstrumentId: id },
+      update: { defaultInstrumentId: id },
+    });
+  }
+
+  async nameExists(name: string, exceptId?: string) {
+    return (
+      (await prisma.instrument.count({
+        where: {
+          normalizedName: normalizeName(name),
+          id: exceptId ? { not: exceptId } : undefined,
+        },
+      })) > 0
+    );
+  }
+
+  private validateName(value: string) {
+    const name = cleanName(value);
+    if (!name) throw new Error("Instrument name is required.");
+    if (name.length > 80) throw new Error("Instrument name is too long.");
+    return name;
+  }
+}
+
+const instrumentsService = new InstrumentsService();
+export default instrumentsService;

--- a/src/services/saved-money-filters.service.ts
+++ b/src/services/saved-money-filters.service.ts
@@ -1,0 +1,114 @@
+import "server-only";
+
+import { MoneyDateRangePreset, TransactionDirection } from "@prisma/client";
+import prisma from "./prisma-service";
+
+const cleanName = (name: string) => name.trim().replace(/\s+/g, " ");
+const normalizeName = (name: string) => cleanName(name).toLocaleLowerCase("en-US");
+
+export type SaveMoneyFilterDto = {
+  name?: string;
+  direction: TransactionDirection;
+  categoryIds: string[];
+  showSubcategories: boolean;
+  rangePreset: MoneyDateRangePreset | null;
+  from: Date | null;
+  to: Date | null;
+  showCashflow: boolean;
+};
+
+export class SavedMoneyFiltersService {
+  async getAll(adminUserId: string) {
+    return prisma.savedMoneyFilter.findMany({
+      where: { adminUserId },
+      orderBy: [{ updatedAt: "desc" }, { name: "asc" }],
+    });
+  }
+
+  async create(adminUserId: string, dto: SaveMoneyFilterDto) {
+    await this.validate(adminUserId, dto);
+    const name = dto.name
+      ? await this.requireUniqueName(adminUserId, dto.name)
+      : await this.nextDefaultName(adminUserId);
+    return prisma.savedMoneyFilter.create({
+      data: {
+        ...dto,
+        categoryIds: [...new Set(dto.categoryIds)],
+        name,
+        normalizedName: normalizeName(name),
+        adminUserId,
+      },
+    });
+  }
+
+  async rename(adminUserId: string, id: string, nameInput: string) {
+    const existing = await prisma.savedMoneyFilter.findFirst({
+      where: { id, adminUserId },
+    });
+    if (!existing) throw new Error("Saved filter not found.");
+    const name = await this.requireUniqueName(adminUserId, nameInput, id);
+    return prisma.savedMoneyFilter.update({
+      where: { id },
+      data: { name, normalizedName: normalizeName(name) },
+    });
+  }
+
+  async delete(adminUserId: string, id: string) {
+    await prisma.savedMoneyFilter.deleteMany({ where: { id, adminUserId } });
+  }
+
+  private async validate(adminUserId: string, dto: SaveMoneyFilterDto) {
+    const categoryIds = [...new Set(dto.categoryIds)];
+    if (categoryIds.length > 10) {
+      throw new Error("A filter can contain at most 10 categories.");
+    }
+    if (categoryIds.length) {
+      const count = await prisma.category.count({
+        where: { id: { in: categoryIds } },
+      });
+      if (count !== categoryIds.length) {
+        throw new Error("One or more selected categories no longer exist.");
+      }
+    }
+    if (!dto.rangePreset && (!dto.from || !dto.to)) {
+      throw new Error("Choose a complete date range.");
+    }
+    if (dto.from && dto.to && dto.from > dto.to) {
+      throw new Error("The start date must be before the end date.");
+    }
+    if (!adminUserId) throw new Error("An authenticated user is required.");
+  }
+
+  private async requireUniqueName(
+    adminUserId: string,
+    value: string,
+    exceptId?: string,
+  ) {
+    const name = cleanName(value);
+    if (!name) throw new Error("Filter name is required.");
+    if (name.length > 80) throw new Error("Filter name is too long.");
+    const exists = await prisma.savedMoneyFilter.count({
+      where: {
+        adminUserId,
+        normalizedName: normalizeName(name),
+        id: exceptId ? { not: exceptId } : undefined,
+      },
+    });
+    if (exists) throw new Error("A saved filter already uses that name.");
+    return name;
+  }
+
+  private async nextDefaultName(adminUserId: string) {
+    const existing = await prisma.savedMoneyFilter.findMany({
+      where: { adminUserId },
+      select: { normalizedName: true },
+    });
+    const names = new Set(existing.map(({ normalizedName }) => normalizedName));
+    let number = 1;
+    while (names.has(`filter ${number}`)) number += 1;
+    return `Filter ${number}`;
+  }
+}
+
+const savedMoneyFiltersService = new SavedMoneyFiltersService();
+export default savedMoneyFiltersService;

--- a/src/services/transactions.service.ts
+++ b/src/services/transactions.service.ts
@@ -12,11 +12,11 @@ export type SaveTransactionDto = {
   comments: string | null;
   time: Date;
   categoryId?: string | null;
-  categoryName?: string | null;
+  instrumentId: string;
 };
 
 export type TransactionFilters = {
-  categoryId?: string;
+  categoryIds?: string[];
   direction?: TransactionDirection;
   from?: Date;
   to?: Date;
@@ -26,7 +26,10 @@ export type TransactionFilters = {
 export class TransactionsService {
   async create(dto: SaveTransactionDto) {
     this.validate(dto);
-    const categoryId = await this.resolveCategory(dto);
+    const [categoryId] = await Promise.all([
+      this.resolveCategory(dto),
+      this.requireInstrument(dto.instrumentId),
+    ]);
     return prisma.transaction.create({
       data: {
         amountCents: dto.amountCents,
@@ -35,13 +38,17 @@ export class TransactionsService {
         comments: dto.comments?.trim() || null,
         time: dto.time,
         categoryId,
+        instrumentId: dto.instrumentId,
       },
     });
   }
 
   async update(id: string, dto: SaveTransactionDto) {
     this.validate(dto);
-    const categoryId = await this.resolveCategory(dto);
+    const [categoryId] = await Promise.all([
+      this.resolveCategory(dto),
+      this.requireInstrument(dto.instrumentId),
+    ]);
     return prisma.transaction.update({
       where: { id },
       data: {
@@ -51,6 +58,7 @@ export class TransactionsService {
         comments: dto.comments?.trim() || null,
         time: dto.time,
         categoryId,
+        instrumentId: dto.instrumentId,
       },
     });
   }
@@ -62,14 +70,17 @@ export class TransactionsService {
   async getById(id: string) {
     return prisma.transaction.findUnique({
       where: { id },
-      include: { category: true },
+      include: { category: true, instrument: true },
     });
   }
 
   async getAll(filters: TransactionFilters = {}) {
     return prisma.transaction.findMany({
       where: this.buildWhere(filters),
-      include: { category: true },
+      include: {
+        category: { include: { parent: true } },
+        instrument: true,
+      },
       orderBy: [{ time: "desc" }, { createdAt: "desc" }],
     });
   }
@@ -126,10 +137,15 @@ export class TransactionsService {
 
   private async resolveCategory(dto: SaveTransactionDto) {
     if (dto.categoryId) {
-      const category = await categoriesService.getCategoryById(dto.categoryId);
-      if (category) return category.id;
+      return (await categoriesService.requireSelectableCategory(dto.categoryId)).id;
     }
-    return (await categoriesService.findOrCreateByName(dto.categoryName)).id;
+    return (await categoriesService.ensureUnclassified()).id;
+  }
+
+  private async requireInstrument(id: string) {
+    const instrument = await prisma.instrument.findUnique({ where: { id } });
+    if (!instrument) throw new Error("Choose a valid transaction instrument.");
+    return instrument;
   }
 
   private validate(dto: SaveTransactionDto) {
@@ -140,11 +156,14 @@ export class TransactionsService {
     }
     if (!dto.title.trim()) throw new Error("Title is required.");
     if (Number.isNaN(dto.time.getTime())) throw new Error("Date is invalid.");
+    if (!dto.instrumentId) throw new Error("Instrument is required.");
   }
 
   private buildWhere(filters: TransactionFilters) {
     return {
-      categoryId: filters.categoryId || undefined,
+      categoryId: filters.categoryIds?.length
+        ? { in: filters.categoryIds }
+        : undefined,
       direction: filters.direction,
       time:
         filters.from || filters.to


### PR DESCRIPTION
## What changed

- Added manageable transaction instruments, credit-card metadata, and a configurable default instrument while preserving one shared money-account balance.
- Added monthly category budgets with server-enforced parent/subcategory allocation limits.
- Enforced subcategory-only transaction classification, with Unclassified as the safe system fallback.
- Rebuilt the desktop transaction dashboard with grouped category selection, inclusive Singapore-aware date presets, saved filters, collapsible statistics and charts, budget comparisons, and richer paginated rows.
- Added per-admin saved-filter persistence with create, apply, rename, and delete flows.
- Expanded the Tailwind theme with reusable admin colors, spacing, borders, and radius tokens.
- Updated the README to reflect the completed money plan.

## Why

This implements the expanded money-workspace plan on top of Lasindu's latest refactor while keeping money calculations exact, reporting rules deterministic, and write invariants in services rather than relying on UI validation.

## User impact

The tracker now supports the September workflow end to end: classify every transaction by a real payment instrument and subcategory, plan monthly category spending, save recurring dashboard views, and inspect cashflow, savings, budget remaining/overflow, trends, and transaction-level budget impact.

## Validation

- `pnpm prisma validate`
- `pnpm lint`
- Full optimized `pnpm build` (Next.js compile, TypeScript, and prerender)
- `git diff --check`

## Deployment note

The database is intentionally treated as fresh money data. Run `pnpm prisma db push` before using the new models and required transaction-instrument relation.